### PR TITLE
Move rider results endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,44 @@ Swagger Documentation can be found [here](http://localhost:8080/docs)
 
 I considered several options for documentation and finally settled on using Swagger UI that uses an OpenAPI json spec. I had initially used a CLI tool to auto-generate an openapi.yaml file, but after upgrading to the NextJS App router, this no longer worked. I searched for a CLI tool that would auto-generate a .yaml file or .json I could serve to my Swagger component, but was unable to find one that worked without adding a huge amount of annotations to my code.
 
-I was skeptical about being able to maintain proper annotations or a manual .yaml file with the complex data structures that this API returns, so I decided to use Postman to generate documentation automatically. I was already using Postman for testing my endpoints and had a well organized and described collection of all my endpoints. The only issue was that Postman does not generate documentation in the OpenAPI format, they use what they call their Collections format. They have their own UI which worked fairly well, but it didn’t look as nice or intuitive as the Swagger UI, and would not be able to be directly hosted within my NextJS app.
+I was skeptical about being able to maintain proper annotations or a manual .yaml file with the complex data structures that this API returns, so I decided to use Postman to generate documentation automatically. I was already using Postman for testing and had a well organized and described collection of all my endpoints. The only issue was that Postman does not generate documentation in the OpenAPI format, they use what they call their Collections format. They have their own UI which worked fairly well, but it didn’t look as nice or intuitive as the Swagger UI, and would not be able to be directly hosted within my NextJS app.
 
-So I searched for a tool to convert a Postman collection to OpenAPI and found there were a few options. I settled on using Postman2OpenAPI, which is used as a javascript library. I then wrote a script so that I can execute this process from the command line when I want to update the documentation.
+So I searched for a tool to convert a Postman collection to OpenAPI format and found there were a few options. I settled on using Postman2OpenAPI, which is used as a javascript library. I then wrote a script so that I can execute this process from the command line when I want to update the documentation.
 
 Although there are a number of steps involved in generating documentation, the nice thing is there is a single source of truth for the data models. You define the request shape in postman, and postman uses the actual shape of the data returned from the endpoint to generate the openapi spec. I prefer this to manually maintaining data shapes in multiple places. In the future, an improvement would be to use a tool that uses the existing typescript definitions to generate the documentation directly, but I was unable to find a tool that worked this way with the NextJS App Router. The one that was closest was `next-rest-framework` but it required significant refactoring of routes, which didn't immediately work for me and it seems like it is not widely used yet, but could be a good option in the future.
 
 ### Steps to update API Documentation
 
 #### Step 1. Make changes to Postman ACS V1 collection
+
 - This is the source of truth. The collection directories should not be nested more than one deep, but they should reflect the folder structure of the API. So if you have a route in `v1/results/recent/route.ts` then the collection should have a folder named `/results/recent` and in that folder are the endpoints found in that route.
-- Add  semantic descriptions i.e. GET a list of recent Results or POST a new rider
+- Add semantic descriptions i.e. GET a list of recent Results or POST a new rider
 - Test the requests and make sure they work
+- After sending the request in postman, click `Save Response` to the upper right of the response (this is important, if you skip this the docs will not have an example response)
+
 #### Step 2. Export as collection.json
+
 - click the three dots next to the collection name
 - click Export
 - select “Collection v2.1”
 - click Export (this will download the file onto your computer)
 - rename the collection if necessary, and use `.collection.json.` It should be. `ACSv1.collection.json`
+
 #### Step 3. Add the file to public directory
+
 - If updating existing documentation, remove old collection.json file and replace it with the new one
 - If creating new documentation, add it alongside the existing collections - `ACSv2.collection.json`
+
 #### Step 4. Update Script if necessary
+
 - If you are adding new documentation i.e. a new version of the API, you will need to update the script to create a new openapi.json file so it doesn’t overwrite the existing one, i.e. acsv2openapi.json. The script is located in `/scripts/convertPostmanToOpenAPI.js`
+
 #### Step 5. Run the script
-- ```node scripts/convertPostmanToOpenAPI.js```
+
+- `node scripts/convertPostmanToOpenAPI.js`
+
 #### Step 6. Adjust the localhost
+
 - For now, you need to update the `localhost` in `openapi.json` to `http://localhost:8080` - We need to do this because postman is losing the local host when exporting the collection. I need to look into fixing this, possibly by using environment variables.
 
 ## Features
@@ -53,7 +65,6 @@ This API is built using
 ## ACS UI
 
 - [ACS Front End](https://github.com/derekvmcintire/acs-next)
-
 
 ## Getting Started
 

--- a/app/api/v1/riders/[id]/results/route.ts
+++ b/app/api/v1/riders/[id]/results/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getResultsByRiderId } from "@/app/_controllers/result";
+import {
+  getResultsNotFoundErrorMessage,
+} from "@/app/_constants/errors";
+import {
+  IRacerHistory,
+} from "@/app/_types/result/types";
+import { AssignRiderToTeamPathParams } from "../teams/route";
+
+export async function GET(_request: NextRequest, context: AssignRiderToTeamPathParams,) {
+  const { params } = context;
+  const { id } = await params;
+
+  try {
+    const results: IRacerHistory | null = await getResultsByRiderId(
+      Number(id),
+    );
+    if (results === null) {
+      return NextResponse.json(
+        { error: getResultsNotFoundErrorMessage(String(id)) },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(results, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: (error as Error).message },
+      { status: 500 },
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prettier:check": "prettier --check \"**/*.{ts,tsx}\"",
     "prettier": "prettier --write \"**/*.{ts,tsx}\"",
     "seed": "ts-node db/seed/index.mjs",
-    "jest": "npx jest"
+    "jest": "npx jest",
+    "docs": "node scripts/convertPostmanToOpenAPI.js"
   },
   "dependencies": {
     "@prisma/client": "^5.21.1",

--- a/public/ACSv1.collection.json
+++ b/public/ACSv1.collection.json
@@ -1376,6 +1376,99 @@
 							"body": "[\n    {\n        \"totalPoints\": 1373,\n        \"riderId\": 25,\n        \"firstName\": \"Demi\",\n        \"lastName\": \"Squiban\",\n        \"hometown\": \"Prague\",\n        \"country\": \"Chile\"\n    },\n    {\n        \"totalPoints\": 1227,\n        \"riderId\": 34,\n        \"firstName\": \"Xandro\",\n        \"lastName\": \"Sormano\",\n        \"hometown\": \"Reykjavik\",\n        \"country\": \"Greece\"\n    },\n    {\n        \"totalPoints\": 1181,\n        \"riderId\": 18,\n        \"firstName\": \"Katarzyna\",\n        \"lastName\": \"Kamna\",\n        \"hometown\": \"Brussels\",\n        \"country\": \"Germany\"\n    },\n    {\n        \"totalPoints\": 1153,\n        \"riderId\": 31,\n        \"firstName\": \"Dynamo\",\n        \"lastName\": \"Torqueheed\",\n        \"hometown\": \"Rijeka\",\n        \"country\": \"Norway\"\n    },\n    {\n        \"totalPoints\": 1128,\n        \"riderId\": 19,\n        \"firstName\": \"Spedvagon\",\n        \"lastName\": \"De Minus\",\n        \"hometown\": \"Chiang Mai\",\n        \"country\": \"Ukraine\"\n    }\n]"
 						}
 					]
+				},
+				{
+					"name": "a list of Results for a single RIder",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/api/v1/riders/52/results",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"v1",
+								"riders",
+								"52",
+								"results"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "a list of Results for a single RIder",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/riders/52/results",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"riders",
+										"52",
+										"results"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/riders/52/results"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:48:27 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"riderId\": 52,\n    \"results\": [\n        {\n            \"year\": 2024,\n            \"races\": [\n                {\n                    \"id\": 504,\n                    \"name\": \"myracev2\",\n                    \"place\": 1,\n                    \"time\": \"23:40.93\",\n                    \"points\": 99,\n                    \"noPlaceCode\": \"NA\",\n                    \"lap\": 1,\n                    \"resultType\": \"default\",\n                    \"eventId\": 505,\n                    \"category\": \"1\",\n                    \"type\": \"Road\",\n                    \"startDate\": \"2024-10-03\",\n                    \"endDate\": null,\n                    \"location\": \"sumwhere, europe\",\n                    \"racers\": 20\n                }\n            ]\n        }\n    ]\n}"
+						}
+					]
 				}
 			],
 			"description": "Next JS App Router Directory"

--- a/public/ACSv1.collection.json
+++ b/public/ACSv1.collection.json
@@ -16,7 +16,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:8080/api/v1/races?limit=100&name=vol&orderby=id&direction=asc",
+							"raw": "http://localhost:8080/api/v1/races?name=vol&orderby=id&direction=asc&limit=2",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -28,11 +28,6 @@
 								"races"
 							],
 							"query": [
-								{
-									"key": "limit",
-									"value": "100",
-									"description": "number: limit the number of races returned"
-								},
 								{
 									"key": "name",
 									"value": "vol",
@@ -59,12 +54,117 @@
 									"value": "",
 									"description": "number: an event id",
 									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "2"
 								}
 							]
 						},
 						"description": "/races\n\nGet a list of races."
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a list of Races",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/races?name=vol&orderby=id&direction=asc&limit=2",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"races"
+									],
+									"query": [
+										{
+											"key": "name",
+											"value": "vol",
+											"description": "string: filter by event name"
+										},
+										{
+											"key": "orderby",
+											"value": "id",
+											"description": "id | eventId | startDate"
+										},
+										{
+											"key": "direction",
+											"value": "asc",
+											"description": "asc | desc"
+										},
+										{
+											"key": "ids",
+											"value": "",
+											"description": "number[]: a listof race ids",
+											"disabled": true
+										},
+										{
+											"key": "eventid",
+											"value": "",
+											"description": "number: an event id",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "2"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/races?name=vol&orderby=id&direction=asc&limit=2"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:22:50 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "[\n    {\n        \"id\": 34,\n        \"eventId\": 34,\n        \"raceTypeId\": 1,\n        \"startDate\": \"2022-05-24\",\n        \"endDate\": null,\n        \"location\": \"Tampere, Tunisia\",\n        \"event\": {\n            \"id\": 34,\n            \"name\": \"Volta Ciclista a Teseney\"\n        },\n        \"raceType\": {\n            \"id\": 1,\n            \"name\": \"Road\",\n            \"description\": \"Road Race Type\"\n        }\n    },\n    {\n        \"id\": 38,\n        \"eventId\": 38,\n        \"raceTypeId\": 1,\n        \"startDate\": \"2021-03-07\",\n        \"endDate\": null,\n        \"location\": \"Prague, Croatia\",\n        \"event\": {\n            \"id\": 38,\n            \"name\": \"Volta Ciclista a Shahdol\"\n        },\n        \"raceType\": {\n            \"id\": 1,\n            \"name\": \"Road\",\n            \"description\": \"Road Race Type\"\n        }\n    }\n]"
+						}
+					]
 				},
 				{
 					"name": "a new Race",
@@ -95,7 +195,84 @@
 						},
 						"description": "/races\n\nCreate a race."
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a new Race",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n      \"name\": \"Killerwat Grass Crit\",\n      \"raceTypeId\": 1,\n      \"startDate\": \"Fri Apr 12 2024\",\n      \"endDate\": null,\n      \"location\": \"Northfield, MA\"\n    }",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/api/v1/races",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"races"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/races"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:23:28 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"id\": 507,\n    \"eventId\": 508,\n    \"raceTypeId\": 1,\n    \"startDate\": \"2024-04-12\",\n    \"endDate\": null,\n    \"location\": \"Northfield, MA\",\n    \"event\": {\n        \"id\": 508,\n        \"name\": \"Killerwat Grass Crit\"\n    },\n    \"raceType\": {\n        \"id\": 1,\n        \"name\": \"Road\",\n        \"description\": \"Road Race Type\"\n    }\n}"
+						}
+					]
 				},
 				{
 					"name": "a list of all Categories",
@@ -118,7 +295,76 @@
 						},
 						"description": "races/categories"
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a list of all Categories",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/races/categories",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"races",
+										"categories"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/races/categories"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:23:38 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "[\n    {\n        \"id\": 1,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Under 14\",\n        \"description\": \"Gran Fondo age group from 1 to 13 for Men\"\n    },\n    {\n        \"id\": 2,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 30-34\",\n        \"description\": \"Gran Fondo age group from 30 to 34 for Women\"\n    },\n    {\n        \"id\": 3,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 35-39\",\n        \"description\": \"Gran Fondo age group from 35 to 39 for Women\"\n    },\n    {\n        \"id\": 4,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 30-34\",\n        \"description\": \"Gran Fondo age group from 30 to 34 for Non Binary\"\n    },\n    {\n        \"id\": 5,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 35-39\",\n        \"description\": \"Gran Fondo age group from 35 to 39 for Non Binary\"\n    },\n    {\n        \"id\": 6,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 25-29\",\n        \"description\": \"Gran Fondo age group from 25 to 29 for Non Binary\"\n    },\n    {\n        \"id\": 7,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 35-39\",\n        \"description\": \"Gran Fondo age group from 35 to 39 for Men\"\n    },\n    {\n        \"id\": 8,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 40-44\",\n        \"description\": \"Gran Fondo age group from 40 to 44 for Men\"\n    },\n    {\n        \"id\": 9,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 30-34\",\n        \"description\": \"Gran Fondo age group from 30 to 34 for Men\"\n    },\n    {\n        \"id\": 10,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 19-24\",\n        \"description\": \"Gran Fondo age group from 19 to 24 for Men\"\n    },\n    {\n        \"id\": 11,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 50-54\",\n        \"description\": \"Gran Fondo age group from 50 to 54 for Men\"\n    },\n    {\n        \"id\": 12,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 55-59\",\n        \"description\": \"Gran Fondo age group from 55 to 59 for Women\"\n    },\n    {\n        \"id\": 13,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 14-16\",\n        \"description\": \"Gran Fondo age group from 14 to 16 for Non Binary\"\n    },\n    {\n        \"id\": 14,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 40-44\",\n        \"description\": \"Gran Fondo age group from 40 to 44 for Non Binary\"\n    },\n    {\n        \"id\": 15,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 60-64\",\n        \"description\": \"Gran Fondo age group from 60 to 64 for Women\"\n    },\n    {\n        \"id\": 16,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 50-54\",\n        \"description\": \"Gran Fondo age group from 50 to 54 for Women\"\n    },\n    {\n        \"id\": 17,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 55-59\",\n        \"description\": \"Gran Fondo age group from 55 to 59 for Non Binary\"\n    },\n    {\n        \"id\": 18,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 65-69\",\n        \"description\": \"Gran Fondo age group from 64 to 69 for Women\"\n    },\n    {\n        \"id\": 19,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 50-54\",\n        \"description\": \"Gran Fondo age group from 50 to 54 for Non Binary\"\n    },\n    {\n        \"id\": 20,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 60-64\",\n        \"description\": \"Gran Fondo age group from 60 to 64 for Men\"\n    },\n    {\n        \"id\": 21,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 45-49\",\n        \"description\": \"Gran Fondo age group from 45 to 49 for Men\"\n    },\n    {\n        \"id\": 22,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 60-64\",\n        \"description\": \"Gran Fondo age group from 60 to 64 for Non Binary\"\n    },\n    {\n        \"id\": 24,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 65-69\",\n        \"description\": \"Gran Fondo age group from 64 to 69 for Non Binary\"\n    },\n    {\n        \"id\": 25,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 70-74\",\n        \"description\": \"Gran Fondo age group from 70 to 74 for Women\"\n    },\n    {\n        \"id\": 27,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 45-49\",\n        \"description\": \"Gran Fondo age group from 45 to 49 for Women\"\n    },\n    {\n        \"id\": 29,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 70-74\",\n        \"description\": \"Gran Fondo age group from 70 to 74 for Non Binary\"\n    },\n    {\n        \"id\": 33,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 75 and Over\",\n        \"description\": \"Gran Fondo age group from 75 to 999 for Women\"\n    },\n    {\n        \"id\": 38,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Under 23\",\n        \"description\": \"Gran Fondo age group from 1 to 22 for Non Binary\"\n    },\n    {\n        \"id\": 43,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Open\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Men\"\n    },\n    {\n        \"id\": 49,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 35+\",\n        \"description\": \"Gran Fondo age group from 35 to 999 for Women\"\n    },\n    {\n        \"id\": 54,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 45+\",\n        \"description\": \"Gran Fondo age group from 45 to 999 for Women\"\n    },\n    {\n        \"id\": 62,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 60+\",\n        \"description\": \"Gran Fondo age group from 60 to 999 for Men\"\n    },\n    {\n        \"id\": 66,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 70+\",\n        \"description\": \"Gran Fondo age group from 70 to 999 for Women\"\n    },\n    {\n        \"id\": 73,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 70+\",\n        \"description\": \"Gran Fondo age group from 70 to 999 for Men\"\n    },\n    {\n        \"id\": 81,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Cat 1\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Women\"\n    },\n    {\n        \"id\": 88,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 17-18\",\n        \"description\": \"Gran Fondo age group from 17 to 18 for Women\"\n    },\n    {\n        \"id\": 90,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Cat 3\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Men\"\n    },\n    {\n        \"id\": 98,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Novice\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 102,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 40-44\",\n        \"description\": \"Gran Fondo age group from 40 to 44 for Women\"\n    },\n    {\n        \"id\": 23,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 14-16\",\n        \"description\": \"Gran Fondo age group from 14 to 16 for Women\"\n    },\n    {\n        \"id\": 26,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 55-59\",\n        \"description\": \"Gran Fondo age group from 55 to 59 for Men\"\n    },\n    {\n        \"id\": 28,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 65-69\",\n        \"description\": \"Gran Fondo age group from 64 to 69 for Men\"\n    },\n    {\n        \"id\": 31,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 70-74\",\n        \"description\": \"Gran Fondo age group from 70 to 74 for Men\"\n    },\n    {\n        \"id\": 34,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 75 and Over\",\n        \"description\": \"Gran Fondo age group from 75 to 999 for Men\"\n    },\n    {\n        \"id\": 37,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Open\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 42,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Under 23\",\n        \"description\": \"Gran Fondo age group from 1 to 22 for Men\"\n    },\n    {\n        \"id\": 48,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Juniors\",\n        \"description\": \"Gran Fondo age group from 1 to 17 for Men\"\n    },\n    {\n        \"id\": 56,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 35+\",\n        \"description\": \"Gran Fondo age group from 35 to 999 for Men\"\n    },\n    {\n        \"id\": 60,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 55+\",\n        \"description\": \"Gran Fondo age group from 55 to 999 for Men\"\n    },\n    {\n        \"id\": 70,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 50+\",\n        \"description\": \"Gran Fondo age group from 50 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 76,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Cat 1\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Men\"\n    },\n    {\n        \"id\": 86,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Cat 2\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 92,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Pro\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 30,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Under 14\",\n        \"description\": \"Gran Fondo age group from 1 to 13 for Women\"\n    },\n    {\n        \"id\": 35,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Juniors\",\n        \"description\": \"Gran Fondo age group from 1 to 17 for Non Binary\"\n    },\n    {\n        \"id\": 39,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 75 and Over\",\n        \"description\": \"Gran Fondo age group from 75 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 45,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 30+\",\n        \"description\": \"Gran Fondo age group from 30 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 50,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Under 23\",\n        \"description\": \"Gran Fondo age group from 1 to 22 for Women\"\n    },\n    {\n        \"id\": 57,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 40+\",\n        \"description\": \"Gran Fondo age group from 40 to 999 for Men\"\n    },\n    {\n        \"id\": 63,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 50+\",\n        \"description\": \"Gran Fondo age group from 50 to 999 for Women\"\n    },\n    {\n        \"id\": 69,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 60+\",\n        \"description\": \"Gran Fondo age group from 60 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 79,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Cat 1\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 87,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Cat 3\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Women\"\n    },\n    {\n        \"id\": 96,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Novice\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Men\"\n    },\n    {\n        \"id\": 32,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 17-18\",\n        \"description\": \"Gran Fondo age group from 17 to 18 for Men\"\n    },\n    {\n        \"id\": 36,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 45-49\",\n        \"description\": \"Gran Fondo age group from 45 to 49 for Non Binary\"\n    },\n    {\n        \"id\": 41,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 30+\",\n        \"description\": \"Gran Fondo age group from 30 to 999 for Men\"\n    },\n    {\n        \"id\": 47,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Open\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Women\"\n    },\n    {\n        \"id\": 51,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 35+\",\n        \"description\": \"Gran Fondo age group from 35 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 58,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 40+\",\n        \"description\": \"Gran Fondo age group from 40 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 64,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 45+\",\n        \"description\": \"Gran Fondo age group from 45 to 999 for Men\"\n    },\n    {\n        \"id\": 72,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 80+\",\n        \"description\": \"Gran Fondo age group from 80 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 78,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Pro\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Men\"\n    },\n    {\n        \"id\": 84,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Cat 2\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Women\"\n    },\n    {\n        \"id\": 97,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Cat 4\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 100,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 14-16\",\n        \"description\": \"Gran Fondo age group from 14 to 16 for Men\"\n    },\n    {\n        \"id\": 40,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 19-24\",\n        \"description\": \"Gran Fondo age group from 19 to 24 for Women\"\n    },\n    {\n        \"id\": 46,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 30+\",\n        \"description\": \"Gran Fondo age group from 30 to 999 for Women\"\n    },\n    {\n        \"id\": 55,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 40+\",\n        \"description\": \"Gran Fondo age group from 40 to 999 for Women\"\n    },\n    {\n        \"id\": 61,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 45+\",\n        \"description\": \"Gran Fondo age group from 45 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 68,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 55+\",\n        \"description\": \"Gran Fondo age group from 55 to 999 for Women\"\n    },\n    {\n        \"id\": 77,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 80+\",\n        \"description\": \"Gran Fondo age group from 80 to 999 for Women\"\n    },\n    {\n        \"id\": 85,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Pro\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Women\"\n    },\n    {\n        \"id\": 91,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Cat 4\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Men\"\n    },\n    {\n        \"id\": 44,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 25-29\",\n        \"description\": \"Gran Fondo age group from 25 to 29 for Women\"\n    },\n    {\n        \"id\": 53,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Juniors\",\n        \"description\": \"Gran Fondo age group from 1 to 17 for Women\"\n    },\n    {\n        \"id\": 59,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 55+\",\n        \"description\": \"Gran Fondo age group from 55 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 67,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women 60+\",\n        \"description\": \"Gran Fondo age group from 60 to 999 for Women\"\n    },\n    {\n        \"id\": 74,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 70+\",\n        \"description\": \"Gran Fondo age group from 70 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 83,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Pro\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 94,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Cat 3\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Non Binary\"\n    },\n    {\n        \"id\": 99,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 25-29\",\n        \"description\": \"Gran Fondo age group from 25 to 29 for Men\"\n    },\n    {\n        \"id\": 52,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 17-18\",\n        \"description\": \"Gran Fondo age group from 17 to 18 for Non Binary\"\n    },\n    {\n        \"id\": 65,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 50+\",\n        \"description\": \"Gran Fondo age group from 50 to 999 for Men\"\n    },\n    {\n        \"id\": 71,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men 80+\",\n        \"description\": \"Gran Fondo age group from 80 to 999 for Men\"\n    },\n    {\n        \"id\": 75,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Pro\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Women\"\n    },\n    {\n        \"id\": 82,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Pro\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Men\"\n    },\n    {\n        \"id\": 95,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Cat 4\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Women\"\n    },\n    {\n        \"id\": 101,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary 19-24\",\n        \"description\": \"Gran Fondo age group from 19 to 24 for Non Binary\"\n    },\n    {\n        \"id\": 80,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Non Binary Under 14\",\n        \"description\": \"Gran Fondo age group from 1 to 13 for Non Binary\"\n    },\n    {\n        \"id\": 89,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Men Cat 2\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Men\"\n    },\n    {\n        \"id\": 93,\n        \"disicpline\": \"Gran Fondo\",\n        \"name\": \"Women Novice\",\n        \"description\": \"Gran Fondo age group from 1 to 999 for Women\"\n    }\n]"
+						}
+					]
 				},
 				{
 					"name": "a total count of Races and Results",
@@ -158,7 +404,93 @@
 						},
 						"description": "/races/totals\n\nGet the total count of races and results for a given time period, grouped by either 'month', 'quarter' or 'year'."
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a total count of Races and Results",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/races/totals?from=2024-01-01&to=2024-09-01&groupby=month",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"races",
+										"totals"
+									],
+									"query": [
+										{
+											"key": "from",
+											"value": "2024-01-01",
+											"description": "YYY-MM-DD: start of date range"
+										},
+										{
+											"key": "to",
+											"value": "2024-09-01",
+											"description": "YYY-MM-DD: end of date range"
+										},
+										{
+											"key": "groupby",
+											"value": "month",
+											"description": "month | quarter | year"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/races/totals?from=2024-01-01&to=2024-09-01&groupby=month"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:23:50 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "[\n    {\n        \"startDate\": \"2024-01-01T05:00:00.000Z\",\n        \"totalRaces\": 6,\n        \"totalRiders\": 205\n    },\n    {\n        \"startDate\": \"2024-02-01T05:00:00.000Z\",\n        \"totalRaces\": 11,\n        \"totalRiders\": 379\n    },\n    {\n        \"startDate\": \"2024-03-01T05:00:00.000Z\",\n        \"totalRaces\": 8,\n        \"totalRiders\": 272\n    },\n    {\n        \"startDate\": \"2024-04-01T04:00:00.000Z\",\n        \"totalRaces\": 14,\n        \"totalRiders\": 315\n    },\n    {\n        \"startDate\": \"2024-05-01T04:00:00.000Z\",\n        \"totalRaces\": 1,\n        \"totalRiders\": 37\n    },\n    {\n        \"startDate\": \"2024-06-01T04:00:00.000Z\",\n        \"totalRaces\": 6,\n        \"totalRiders\": 203\n    },\n    {\n        \"startDate\": \"2024-07-01T04:00:00.000Z\",\n        \"totalRaces\": 9,\n        \"totalRiders\": 300\n    },\n    {\n        \"startDate\": \"2024-08-01T04:00:00.000Z\",\n        \"totalRaces\": 11,\n        \"totalRiders\": 385\n    }\n]"
+						}
+					]
 				},
 				{
 					"name": "a list of Results for a single Race",
@@ -182,7 +514,77 @@
 						},
 						"description": "/races/\\[id\\]/results"
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a list of Results for a single Race",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/races/5/results",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"races",
+										"5",
+										"results"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/races/5/results"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:24:09 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "[\n    {\n        \"id\": 152,\n        \"eventId\": 5,\n        \"riderId\": 19,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 1,\n        \"time\": \"\",\n        \"points\": 115,\n        \"rider\": {\n            \"id\": 19,\n            \"firstName\": \"Spedvagon\",\n            \"lastName\": \"De Minus\",\n            \"dob\": \"Mon Jan 15 2001\",\n            \"country\": \"Ukraine\",\n            \"hometown\": \"Chiang Mai\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ec/florian-senechal-2024.jpg\",\n            \"strava\": \"996863\",\n            \"insta\": \"pl\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 161,\n        \"eventId\": 5,\n        \"riderId\": 17,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 4,\n        \"time\": \"\",\n        \"points\": 70,\n        \"rider\": {\n            \"id\": 17,\n            \"firstName\": \"Biniam\",\n            \"lastName\": \"McRothair\",\n            \"dob\": \"Thu Jul 12 1990\",\n            \"country\": \"Australia\",\n            \"hometown\": \"Metz\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ff/lorena-wiebes-2024-n2.jpeg\",\n            \"strava\": \"4708197\",\n            \"insta\": \"na\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 170,\n        \"eventId\": 5,\n        \"riderId\": 41,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 19,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 41,\n            \"firstName\": \"Magnus\",\n            \"lastName\": \"Ghekiere\",\n            \"dob\": \"Wed Jan 09 1985\",\n            \"country\": \"Norway\",\n            \"hometown\": \"Uddevella\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg\",\n            \"strava\": \"9645046\",\n            \"insta\": \"zovqkuqdqpqazl\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 179,\n        \"eventId\": 5,\n        \"riderId\": 24,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 2,\n        \"time\": \"\",\n        \"points\": 100,\n        \"rider\": {\n            \"id\": 24,\n            \"firstName\": \"Murbo\",\n            \"lastName\": \"Barder\",\n            \"dob\": \"Wed May 09 1984\",\n            \"country\": \"Guatemala\",\n            \"hometown\": \"Cordoba\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg\",\n            \"strava\": \"1266622\",\n            \"insta\": \"agifgzyfzoqhx\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 144,\n        \"eventId\": 5,\n        \"riderId\": 8,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 33,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 8,\n            \"firstName\": \"Katarzyna\",\n            \"lastName\": \"Paceclim\",\n            \"dob\": \"Wed Aug 30 1995\",\n            \"country\": \"Norway\",\n            \"hometown\": \"Zagreb\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg\",\n            \"strava\": \"6701426\",\n            \"insta\": \"nkwl\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 153,\n        \"eventId\": 5,\n        \"riderId\": 20,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 37,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 20,\n            \"firstName\": \"Mathieu\",\n            \"lastName\": \"Cornt\",\n            \"dob\": \"Fri May 18 1990\",\n            \"country\": \"Puerto Rico\",\n            \"hometown\": \"Hoi An\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/fb/kasper-asgreen-2024.jpeg\",\n            \"strava\": \"4682464\",\n            \"insta\": \"qtm\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 162,\n        \"eventId\": 5,\n        \"riderId\": 34,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 27,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 34,\n            \"firstName\": \"Xandro\",\n            \"lastName\": \"Sormano\",\n            \"dob\": \"Thu Aug 24 2006\",\n            \"country\": \"Greece\",\n            \"hometown\": \"Reykjavik\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg\",\n            \"strava\": \"6278699\",\n            \"insta\": \"llcuzaagyc\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 171,\n        \"eventId\": 5,\n        \"riderId\": 28,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 28,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 28,\n            \"firstName\": \"Xandro\",\n            \"lastName\": \"Terravelo\",\n            \"dob\": \"Tue Feb 15 2005\",\n            \"country\": \"Jordan\",\n            \"hometown\": \"Metz\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/aa/remco-evenepoel-2024.jpeg\",\n            \"strava\": \"8189011\",\n            \"insta\": \"jldyumobpgwcp\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 180,\n        \"eventId\": 5,\n        \"riderId\": 39,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 10,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 39,\n            \"firstName\": \"Marte\",\n            \"lastName\": \"Rickymas\",\n            \"dob\": \"Mon Mar 27 2006\",\n            \"country\": \"Wales\",\n            \"hometown\": \"Reykjavik\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg\",\n            \"strava\": \"9912067\",\n            \"insta\": \"fgt\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 150,\n        \"eventId\": 5,\n        \"riderId\": 16,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 8,\n        \"time\": \"\",\n        \"points\": 10,\n        \"rider\": {\n            \"id\": 16,\n            \"firstName\": \"Matej\",\n            \"lastName\": \"Kamna\",\n            \"dob\": \"Tue May 06 1997\",\n            \"country\": \"Belarus\",\n            \"hometown\": \"Asmara\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/cc/rigoberto-uran-2024.jpeg\",\n            \"strava\": \"8372609\",\n            \"insta\": \"z\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 160,\n        \"eventId\": 5,\n        \"riderId\": 31,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 31,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 31,\n            \"firstName\": \"Dynamo\",\n            \"lastName\": \"Torqueheed\",\n            \"dob\": \"Fri May 18 2001\",\n            \"country\": \"Norway\",\n            \"hometown\": \"Rijeka\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg\",\n            \"strava\": \"3172617\",\n            \"insta\": \"wieajqaxc\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 168,\n        \"eventId\": 5,\n        \"riderId\": 38,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 26,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 38,\n            \"firstName\": \"Geraint\",\n            \"lastName\": \"Alafilippo\",\n            \"dob\": \"Mon Jan 31 2005\",\n            \"country\": \"Panama\",\n            \"hometown\": \"Tibooburra\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg\",\n            \"strava\": \"4181190\",\n            \"insta\": \"juhxht\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 177,\n        \"eventId\": 5,\n        \"riderId\": 25,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 30,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 25,\n            \"firstName\": \"Demi\",\n            \"lastName\": \"Squiban\",\n            \"dob\": \"Sun Jul 21 1991\",\n            \"country\": \"Chile\",\n            \"hometown\": \"Prague\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg\",\n            \"strava\": \"6696292\",\n            \"insta\": \"hulmdau\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 151,\n        \"eventId\": 5,\n        \"riderId\": 11,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 11,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 11,\n            \"firstName\": \"Mattias\",\n            \"lastName\": \"McRothair\",\n            \"dob\": \"Fri Nov 15 1991\",\n            \"country\": \"Peru\",\n            \"hometown\": \"Vimmerby\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/bd/merhawi-kudus-2024.png\",\n            \"strava\": \"6361228\",\n            \"insta\": \"fiesujbkwk\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 156,\n        \"eventId\": 5,\n        \"riderId\": 32,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 9,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 32,\n            \"firstName\": \"Zephyr\",\n            \"lastName\": \"Tourbolet\",\n            \"dob\": \"Mon Apr 23 1984\",\n            \"country\": \"Scotland\",\n            \"hometown\": \"Broken Hill\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/fa/michael-morkov-2024.jpg\",\n            \"strava\": \"1591863\",\n            \"insta\": \"xvcyvkovdic\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 165,\n        \"eventId\": 5,\n        \"riderId\": 15,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 7,\n        \"time\": \"\",\n        \"points\": 25,\n        \"rider\": {\n            \"id\": 15,\n            \"firstName\": \"Sepp\",\n            \"lastName\": \"Markrus\",\n            \"dob\": \"Sat Oct 20 1984\",\n            \"country\": \"Puerto Rico\",\n            \"hometown\": \"Passe de Kourizo\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg\",\n            \"strava\": \"9797010\",\n            \"insta\": \"oedhxommck\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 178,\n        \"eventId\": 5,\n        \"riderId\": 29,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 35,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 29,\n            \"firstName\": \"Mattias\",\n            \"lastName\": \"Siverkov\",\n            \"dob\": \"Sat Aug 27 1988\",\n            \"country\": \"Estonia\",\n            \"hometown\": \"Grenada\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/fc/lotte-kopecky-2024-n2.jpeg\",\n            \"strava\": \"3054718\",\n            \"insta\": \"aquzntsg\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 148,\n        \"eventId\": 5,\n        \"riderId\": 9,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 16,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 9,\n            \"firstName\": \"Thalita\",\n            \"lastName\": \"Van Vleumower\",\n            \"dob\": \"Thu Feb 27 1986\",\n            \"country\": \"Croatia\",\n            \"hometown\": \"Fox Glacier\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/dd/geraint-thomas-2024.jpg\",\n            \"strava\": \"1619538\",\n            \"insta\": \"ndrgahaxqungq\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 155,\n        \"eventId\": 5,\n        \"riderId\": 26,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 20,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 26,\n            \"firstName\": \"Filippo\",\n            \"lastName\": \"Paceclim\",\n            \"dob\": \"Mon Mar 02 1987\",\n            \"country\": \"Indonesia\",\n            \"hometown\": \"Rijeka\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg\",\n            \"strava\": \"4358756\",\n            \"insta\": \"gdxyfxuiyrghvn\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 164,\n        \"eventId\": 5,\n        \"riderId\": 36,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 17,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 36,\n            \"firstName\": \"Enric\",\n            \"lastName\": \"Giauman\",\n            \"dob\": \"Wed Sep 28 2005\",\n            \"country\": \"Slovenia\",\n            \"hometown\": \"Tampere\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ce/grace-brown-2022-n2.jpg\",\n            \"strava\": \"9281875\",\n            \"insta\": \"axde\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 175,\n        \"eventId\": 5,\n        \"riderId\": 35,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 34,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 35,\n            \"firstName\": \"Harold\",\n            \"lastName\": \"Koolkoolkool\",\n            \"dob\": \"Sat Jun 05 2004\",\n            \"country\": \"Sweden\",\n            \"hometown\": \"Seoni\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg\",\n            \"strava\": \"4893701\",\n            \"insta\": \"efatihvkf\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 145,\n        \"eventId\": 5,\n        \"riderId\": 13,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 3,\n        \"time\": \"\",\n        \"points\": 85,\n        \"rider\": {\n            \"id\": 13,\n            \"firstName\": \"Katarzyna\",\n            \"lastName\": \"Lancia-pneumatici\",\n            \"dob\": \"Fri Nov 05 1999\",\n            \"country\": \"Greece\",\n            \"hometown\": \"Malaga\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/dd/geraint-thomas-2024.jpg\",\n            \"strava\": \"4413982\",\n            \"insta\": \"n\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 154,\n        \"eventId\": 5,\n        \"riderId\": 22,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 36,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 22,\n            \"firstName\": \"Jhonatan\",\n            \"lastName\": \"Cuss\",\n            \"dob\": \"Thu Oct 19 2000\",\n            \"country\": \"Scotland\",\n            \"hometown\": \"Flinders Rangers\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ae/marianne-vos-2024.png\",\n            \"strava\": \"7086712\",\n            \"insta\": \"vfsohk\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 163,\n        \"eventId\": 5,\n        \"riderId\": 12,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 32,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 12,\n            \"firstName\": \"Zestnor\",\n            \"lastName\": \"Galb\",\n            \"dob\": \"Tue Oct 21 2003\",\n            \"country\": \"Hungary\",\n            \"hometown\": \"Burlington\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg\",\n            \"strava\": \"3226592\",\n            \"insta\": \"gxwlqavyphohkc\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 172,\n        \"eventId\": 5,\n        \"riderId\": 42,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 13,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 42,\n            \"firstName\": \"Matteo\",\n            \"lastName\": \"Arrow\",\n            \"dob\": \"Mon Jun 04 1990\",\n            \"country\": \"Kenya\",\n            \"hometown\": \"Florence\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/bd/marc-soler-2024-n2.jpeg\",\n            \"strava\": \"127532\",\n            \"insta\": \"tjv\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 146,\n        \"eventId\": 5,\n        \"riderId\": 21,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 12,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 21,\n            \"firstName\": \"Xandro\",\n            \"lastName\": \"Chabbo\",\n            \"dob\": \"Thu Mar 09 2006\",\n            \"country\": \"Burundi\",\n            \"hometown\": \"Hamburg\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/dc/ben-healy-2024.jpeg\",\n            \"strava\": \"7355646\",\n            \"insta\": \"c\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 159,\n        \"eventId\": 5,\n        \"riderId\": 33,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 15,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 33,\n            \"firstName\": \"Fem\",\n            \"lastName\": \"Johanndort\",\n            \"dob\": \"Sun Nov 14 1993\",\n            \"country\": \"Lithuania\",\n            \"hometown\": \"Bled\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/cf/amber-kraak-2024.jpg\",\n            \"strava\": \"2005234\",\n            \"insta\": \"zxgmcqzzzme\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 166,\n        \"eventId\": 5,\n        \"riderId\": 40,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 18,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 40,\n            \"firstName\": \"Sonic\",\n            \"lastName\": \"Rowerowski\",\n            \"dob\": \"Fri Oct 01 2004\",\n            \"country\": \"Bulgaria\",\n            \"hometown\": \"Dublin\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg\",\n            \"strava\": \"9902889\",\n            \"insta\": \"utmhbermbmzgar\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 174,\n        \"eventId\": 5,\n        \"riderId\": 43,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 29,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 43,\n            \"firstName\": \"Antonia\",\n            \"lastName\": \"Ciccolo\",\n            \"dob\": \"Sat Jul 07 1990\",\n            \"country\": \"Panama\",\n            \"hometown\": \"Burlington\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/fa/michael-morkov-2024.jpg\",\n            \"strava\": \"298111\",\n            \"insta\": \"phpo\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 147,\n        \"eventId\": 5,\n        \"riderId\": 14,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 21,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 14,\n            \"firstName\": \"Harold\",\n            \"lastName\": \"Vons\",\n            \"dob\": \"Fri Aug 22 2003\",\n            \"country\": \"Malaysia\",\n            \"hometown\": \"Dao Timmi\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg\",\n            \"strava\": \"6623078\",\n            \"insta\": \"gkweanhw\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 158,\n        \"eventId\": 5,\n        \"riderId\": 27,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 6,\n        \"time\": \"\",\n        \"points\": 40,\n        \"rider\": {\n            \"id\": 27,\n            \"firstName\": \"Cecilie\",\n            \"lastName\": \"Gavia\",\n            \"dob\": \"Tue Mar 01 1994\",\n            \"country\": \"Peru\",\n            \"hometown\": \"Broken Hill\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ab/tobias-halland-johannessen-2024.png\",\n            \"strava\": \"2461522\",\n            \"insta\": \"ckhoqbgvmbhkfbp\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 167,\n        \"eventId\": 5,\n        \"riderId\": 23,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 14,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 23,\n            \"firstName\": \"Cecilie\",\n            \"lastName\": \"Gamma\",\n            \"dob\": \"Mon May 12 1997\",\n            \"country\": \"Wales\",\n            \"hometown\": \"Ulsan\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg\",\n            \"strava\": \"1162576\",\n            \"insta\": \"mteheltvajsgkfn\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 173,\n        \"eventId\": 5,\n        \"riderId\": 18,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 24,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 18,\n            \"firstName\": \"Katarzyna\",\n            \"lastName\": \"Kamna\",\n            \"dob\": \"Thu Feb 26 2004\",\n            \"country\": \"Germany\",\n            \"hometown\": \"Brussels\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg\",\n            \"strava\": \"353540\",\n            \"insta\": \"dvzhiwiecarrgzj\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 149,\n        \"eventId\": 5,\n        \"riderId\": 10,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 25,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 10,\n            \"firstName\": \"Harold\",\n            \"lastName\": \"Gamma\",\n            \"dob\": \"Sun Aug 05 2001\",\n            \"country\": \"Croatia\",\n            \"hometown\": \"Dao Timmi\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/cc/rigoberto-uran-2024.jpeg\",\n            \"strava\": \"7898112\",\n            \"insta\": \"fclhne\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 157,\n        \"eventId\": 5,\n        \"riderId\": 30,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 22,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 30,\n            \"firstName\": \"Nielson\",\n            \"lastName\": \"Tacktheritrix\",\n            \"dob\": \"Wed Mar 29 2000\",\n            \"country\": \"UK\",\n            \"hometown\": \"Dublin\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg\",\n            \"strava\": \"5447158\",\n            \"insta\": \"qokpuhzkyxgf\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 169,\n        \"eventId\": 5,\n        \"riderId\": 37,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 23,\n        \"time\": \"\",\n        \"points\": 0,\n        \"rider\": {\n            \"id\": 37,\n            \"firstName\": \"Thymen\",\n            \"lastName\": \"Madyuas\",\n            \"dob\": \"Tue Feb 06 1990\",\n            \"country\": \"Nicaragua\",\n            \"hometown\": \"Debark\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ea/alberto-bettiol-2024-n2-n3.jpg\",\n            \"strava\": \"7899573\",\n            \"insta\": \"aoylnn\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    },\n    {\n        \"id\": 176,\n        \"eventId\": 5,\n        \"riderId\": 44,\n        \"resultTypeId\": 1,\n        \"noPlaceCodeTypeId\": 1,\n        \"lap\": null,\n        \"place\": 5,\n        \"time\": \"\",\n        \"points\": 55,\n        \"rider\": {\n            \"id\": 44,\n            \"firstName\": \"Cyclistopher\",\n            \"lastName\": \"Velocepede\",\n            \"dob\": \"Sun Jan 14 2001\",\n            \"country\": \"Greece\",\n            \"hometown\": \"Mildura\",\n            \"photo\": \"https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg\",\n            \"strava\": \"9209250\",\n            \"insta\": \"hxutcmnydtyyiih\",\n            \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n        },\n        \"event\": {\n            \"id\": 5,\n            \"name\": \"Dao Timmi Shahdol\",\n            \"Race\": [\n                {\n                    \"id\": 5,\n                    \"eventId\": 5,\n                    \"raceTypeId\": 1,\n                    \"startDate\": \"2021-06-27\",\n                    \"endDate\": null,\n                    \"location\": \"Antalya, Lithuania\",\n                    \"raceType\": {\n                        \"id\": 1,\n                        \"name\": \"Road\",\n                        \"description\": \"Road Race Type\"\n                    }\n                }\n            ]\n        },\n        \"resultType\": {\n            \"id\": 1,\n            \"name\": \"default\",\n            \"description\": \"Default Result Type\"\n        },\n        \"noPlaceCodeType\": {\n            \"id\": 1,\n            \"name\": \"NA\",\n            \"description\": \"Participant Placed\"\n        }\n    }\n]"
+						}
+					]
 				},
 				{
 					"name": "a list of recent Results",
@@ -229,7 +631,100 @@
 						},
 						"description": "races/results/recent\n\nGet a list of the most recent races with results. You can limit the. number of races or results that are returned. You can also filter by location."
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a list of recent Results",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/races/results/recent?limit=2&resultlimit=3",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"races",
+										"results",
+										"recent"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "2",
+											"description": "number: limit the number of races returned"
+										},
+										{
+											"key": "resultlimit",
+											"value": "3",
+											"description": "number: limit the number of results returned for each race"
+										},
+										{
+											"key": "location",
+											"value": "",
+											"description": "string: filter by location",
+											"disabled": true
+										},
+										{
+											"key": "",
+											"value": "",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/races/results/recent?limit=2&resultlimit=3"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:24:19 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "[\n    {\n        \"raceId\": 150,\n        \"results\": [\n            {\n                \"id\": 5222,\n                \"eventId\": 150,\n                \"riderId\": 48,\n                \"resultTypeId\": 1,\n                \"noPlaceCodeTypeId\": 1,\n                \"lap\": null,\n                \"place\": 1,\n                \"time\": \"\",\n                \"points\": 114,\n                \"rider\": {\n                    \"id\": 48,\n                    \"firstName\": \"Laurens\",\n                    \"lastName\": \"Grimay\",\n                    \"dob\": \"Mon Jun 10 1985\",\n                    \"country\": \"Greece\",\n                    \"hometown\": \"Modena\",\n                    \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg\",\n                    \"strava\": \"3734063\",\n                    \"insta\": \"groxqsfmpy\",\n                    \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n                },\n                \"event\": {\n                    \"id\": 150,\n                    \"name\": \"Djado Plateau a Al Malaqi\",\n                    \"Race\": [\n                        {\n                            \"id\": 150,\n                            \"eventId\": 150,\n                            \"raceTypeId\": 1,\n                            \"startDate\": \"2024-11-06\",\n                            \"endDate\": null,\n                            \"location\": \"Akola, Ukraine\",\n                            \"raceType\": {\n                                \"id\": 1,\n                                \"name\": \"Road\",\n                                \"description\": \"Road Race Type\"\n                            }\n                        }\n                    ]\n                },\n                \"resultType\": {\n                    \"id\": 1,\n                    \"name\": \"default\",\n                    \"description\": \"Default Result Type\"\n                },\n                \"noPlaceCodeType\": {\n                    \"id\": 1,\n                    \"name\": \"NA\",\n                    \"description\": \"Participant Placed\"\n                }\n            },\n            {\n                \"id\": 5206,\n                \"eventId\": 150,\n                \"riderId\": 35,\n                \"resultTypeId\": 1,\n                \"noPlaceCodeTypeId\": 1,\n                \"lap\": null,\n                \"place\": 2,\n                \"time\": \"\",\n                \"points\": 99,\n                \"rider\": {\n                    \"id\": 35,\n                    \"firstName\": \"Harold\",\n                    \"lastName\": \"Koolkoolkool\",\n                    \"dob\": \"Sat Jun 05 2004\",\n                    \"country\": \"Sweden\",\n                    \"hometown\": \"Seoni\",\n                    \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg\",\n                    \"strava\": \"4893701\",\n                    \"insta\": \"efatihvkf\",\n                    \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n                },\n                \"event\": {\n                    \"id\": 150,\n                    \"name\": \"Djado Plateau a Al Malaqi\",\n                    \"Race\": [\n                        {\n                            \"id\": 150,\n                            \"eventId\": 150,\n                            \"raceTypeId\": 1,\n                            \"startDate\": \"2024-11-06\",\n                            \"endDate\": null,\n                            \"location\": \"Akola, Ukraine\",\n                            \"raceType\": {\n                                \"id\": 1,\n                                \"name\": \"Road\",\n                                \"description\": \"Road Race Type\"\n                            }\n                        }\n                    ]\n                },\n                \"resultType\": {\n                    \"id\": 1,\n                    \"name\": \"default\",\n                    \"description\": \"Default Result Type\"\n                },\n                \"noPlaceCodeType\": {\n                    \"id\": 1,\n                    \"name\": \"NA\",\n                    \"description\": \"Participant Placed\"\n                }\n            },\n            {\n                \"id\": 5225,\n                \"eventId\": 150,\n                \"riderId\": 49,\n                \"resultTypeId\": 1,\n                \"noPlaceCodeTypeId\": 1,\n                \"lap\": null,\n                \"place\": 3,\n                \"time\": \"\",\n                \"points\": 84,\n                \"rider\": {\n                    \"id\": 49,\n                    \"firstName\": \"Cecilie\",\n                    \"lastName\": \"Markrus\",\n                    \"dob\": \"Thu Apr 26 2001\",\n                    \"country\": \"Guatemala\",\n                    \"hometown\": \"Broken Hill\",\n                    \"photo\": \"https://www.procyclingstats.com/images/riders/bp/aa/richard-carapaz-2024.jpeg\",\n                    \"strava\": \"1599291\",\n                    \"insta\": \"g\",\n                    \"about\": \"They think I'm just some dumb hick. They said that to me, at a dinner!\"\n                },\n                \"event\": {\n                    \"id\": 150,\n                    \"name\": \"Djado Plateau a Al Malaqi\",\n                    \"Race\": [\n                        {\n                            \"id\": 150,\n                            \"eventId\": 150,\n                            \"raceTypeId\": 1,\n                            \"startDate\": \"2024-11-06\",\n                            \"endDate\": null,\n                            \"location\": \"Akola, Ukraine\",\n                            \"raceType\": {\n                                \"id\": 1,\n                                \"name\": \"Road\",\n                                \"description\": \"Road Race Type\"\n                            }\n                        }\n                    ]\n                },\n                \"resultType\": {\n                    \"id\": 1,\n                    \"name\": \"default\",\n                    \"description\": \"Default Result Type\"\n                },\n                \"noPlaceCodeType\": {\n                    \"id\": 1,\n                    \"name\": \"NA\",\n                    \"description\": \"Participant Placed\"\n                }\n            }\n        ]\n    },\n    {\n        \"raceId\": 490,\n        \"results\": []\n    }\n]"
+						}
+					]
 				}
 			],
 			"description": "Next JS App Router Directory"
@@ -266,7 +761,84 @@
 						},
 						"description": "/results\n\nCreate a new result."
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a new Result",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n      \"eventId\": 1,\n      \"resultTypeId\": 1,\n      \"riderId\": 1,\n      \"noPlaceCodeTypeId\": 1,\n      \"lap\": 1,\n      \"place\": 4,\n      \"time\": \"\",\n      \"points\": 1\n    }",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/api/v1/results",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"results"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/results"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:24:32 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"id\": 17190,\n    \"eventId\": 1,\n    \"riderId\": 1,\n    \"resultTypeId\": 1,\n    \"noPlaceCodeTypeId\": 1,\n    \"lap\": 1,\n    \"place\": 4,\n    \"time\": null,\n    \"points\": 1\n}"
+						}
+					]
 				},
 				{
 					"name": "a list of Results for a single Rider",
@@ -295,7 +867,82 @@
 						},
 						"description": "/results\n\nGet results for a single rider.\n\n@TODO this endpoint will be updated to /riders/\\[id\\]/results"
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a list of Results for a single Rider",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/results?riderId=52",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"results"
+									],
+									"query": [
+										{
+											"key": "riderId",
+											"value": "52",
+											"description": "number: a rider id"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/results?riderId=52"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:25:40 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"riderId\": 52,\n    \"results\": [\n        {\n            \"year\": 2024,\n            \"races\": [\n                {\n                    \"id\": 504,\n                    \"name\": \"myracev2\",\n                    \"place\": 1,\n                    \"time\": \"23:40.93\",\n                    \"points\": 99,\n                    \"noPlaceCode\": \"NA\",\n                    \"lap\": 1,\n                    \"resultType\": \"default\",\n                    \"eventId\": 505,\n                    \"category\": \"1\",\n                    \"type\": \"Road\",\n                    \"startDate\": \"2024-10-03\",\n                    \"endDate\": null,\n                    \"location\": \"sumwhere, europe\",\n                    \"racers\": 20\n                }\n            ]\n        }\n    ]\n}"
+						}
+					]
 				}
 			],
 			"description": "Next JS App Router Directory"
@@ -332,7 +979,84 @@
 						},
 						"description": "/riders\n\nCreate a new rider."
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a new Rider",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"firstName\": \"Mipper\",\n  \"lastName\": \"Mopperson\",\n  \"dob\": \"1990-01-01\",\n  \"country\": \"USA\",\n  \"hometown\": \"New York, NY\",\n  \"photo\": \"https://www.procyclingstats.com/images/riders/bp/bf/julian-alaphilippe-2024.jpeg\",\n  \"strava\": \"87935790234\",\n  \"insta\": \"portamip\",\n  \"about\": \"It reaaaallly bothered me.\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/api/v1/riders",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"riders"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/riders"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:25:55 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"id\": 74,\n    \"firstName\": \"Mipper\",\n    \"lastName\": \"Mopperson\",\n    \"dob\": \"1990-01-01\",\n    \"country\": \"USA\",\n    \"hometown\": \"New York, NY\",\n    \"photo\": \"https://www.procyclingstats.com/images/riders/bp/bf/julian-alaphilippe-2024.jpeg\",\n    \"strava\": \"87935790234\",\n    \"insta\": \"portamip\",\n    \"about\": \"It reaaaallly bothered me.\"\n}"
+						}
+					]
 				},
 				{
 					"name": "a single Rider",
@@ -355,7 +1079,76 @@
 						},
 						"description": "/riders/\\[id\\]\n\nGet a single Rider."
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a single Rider",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/riders/4",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"riders",
+										"4"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/riders/4"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:26:26 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"id\": 4,\n    \"currentTeam\": \"TJ Maxx Equipo\",\n    \"name\": {\n        \"first\": \"Geraint\",\n        \"last\": \"Kamna\"\n    },\n    \"teams\": [\n        {\n            \"year\": 2024,\n            \"name\": \"TJ Maxx Equipo\",\n            \"id\": 3,\n            \"url\": \"\",\n            \"description\": \"TJ Maxx Equipo is a racing community. We help each other keep things dialed on and off the bike to realize one another's  athletic goals.\"\n        }\n    ],\n    \"socials\": {\n        \"strava\": \"715907\",\n        \"insta\": \"j\"\n    },\n    \"categories\": [\n        {\n            \"disicpline\": \"road\",\n            \"category\": 1\n        }\n    ],\n    \"hometown\": {\n        \"country\": \"Syria\",\n        \"city\": \"Copenhagen\"\n    },\n    \"dob\": \"Sat Jun 27 1998\",\n    \"photo\": \"https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg\",\n    \"wins\": 43\n}"
+						}
+					]
 				},
 				{
 					"name": "http://localhost:8080/api/latest/riders/1/teams",
@@ -387,7 +1180,86 @@
 							]
 						}
 					},
-					"response": []
+					"response": [
+						{
+							"name": "http://localhost:8080/api/latest/riders/1/teams",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"teamId\": 2\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/api/v1/riders/4/teams",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"riders",
+										"4",
+										"teams"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/riders/4/teams"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:27:11 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"id\": 56,\n    \"riderId\": 4,\n    \"teamId\": 2\n}"
+						}
+					]
 				},
 				{
 					"name": "a list of Riders by Rank",
@@ -422,7 +1294,88 @@
 						},
 						"description": "/riders/rankings\n\nGet a list of riders by rank. Returns a list of riders who have accumulated the most points within a calendar year in descending order. Defaults to the current calendar year."
 					},
-					"response": []
+					"response": [
+						{
+							"name": "a list of Riders by Rank",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/api/v1/riders/rankings?limit=5&year=2024",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"api",
+										"v1",
+										"riders",
+										"rankings"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "5",
+											"description": "number: limit the number of ranings returned"
+										},
+										{
+											"key": "year",
+											"value": "2024",
+											"description": "number: a calendar year"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "access-control-allow-headers",
+									"value": "Content-Type"
+								},
+								{
+									"key": "access-control-allow-methods",
+									"value": "GET, POST, OPTIONS"
+								},
+								{
+									"key": "access-control-allow-origin",
+									"value": "*"
+								},
+								{
+									"key": "x-middleware-rewrite",
+									"value": "/api/v1/riders/rankings?limit=5&year=2024"
+								},
+								{
+									"key": "vary",
+									"value": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json"
+								},
+								{
+									"key": "Date",
+									"value": "Mon, 18 Nov 2024 01:27:31 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Keep-Alive",
+									"value": "timeout=5"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								}
+							],
+							"cookie": [],
+							"body": "[\n    {\n        \"totalPoints\": 1373,\n        \"riderId\": 25,\n        \"firstName\": \"Demi\",\n        \"lastName\": \"Squiban\",\n        \"hometown\": \"Prague\",\n        \"country\": \"Chile\"\n    },\n    {\n        \"totalPoints\": 1227,\n        \"riderId\": 34,\n        \"firstName\": \"Xandro\",\n        \"lastName\": \"Sormano\",\n        \"hometown\": \"Reykjavik\",\n        \"country\": \"Greece\"\n    },\n    {\n        \"totalPoints\": 1181,\n        \"riderId\": 18,\n        \"firstName\": \"Katarzyna\",\n        \"lastName\": \"Kamna\",\n        \"hometown\": \"Brussels\",\n        \"country\": \"Germany\"\n    },\n    {\n        \"totalPoints\": 1153,\n        \"riderId\": 31,\n        \"firstName\": \"Dynamo\",\n        \"lastName\": \"Torqueheed\",\n        \"hometown\": \"Rijeka\",\n        \"country\": \"Norway\"\n    },\n    {\n        \"totalPoints\": 1128,\n        \"riderId\": 19,\n        \"firstName\": \"Spedvagon\",\n        \"lastName\": \"De Minus\",\n        \"hometown\": \"Chiang Mai\",\n        \"country\": \"Ukraine\"\n    }\n]"
+						}
+					]
 				}
 			],
 			"description": "Next JS App Router Directory"

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -8,7 +8,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8080"
+      "url": "http://localhost"
     }
   ],
   "paths": {
@@ -21,15 +21,6 @@
         "description": "/races\n\nGet a list of races.",
         "operationId": "aListOfRaces",
         "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "example": "100"
-            },
-            "description": "number: limit the number of races returned"
-          },
           {
             "name": "name",
             "in": "query",
@@ -74,11 +65,217 @@
               "example": ""
             },
             "description": "number: an event id"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "example": "2"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "a list of Races",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:22:50 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/races?name=vol&orderby=id&direction=asc&limit=2"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "endDate": {
+                        "nullable": true,
+                        "example": null
+                      },
+                      "event": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number",
+                            "example": 34
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Volta Ciclista a Teseney"
+                          }
+                        }
+                      },
+                      "eventId": {
+                        "type": "number",
+                        "example": 34
+                      },
+                      "id": {
+                        "type": "number",
+                        "example": 34
+                      },
+                      "location": {
+                        "type": "string",
+                        "example": "Tampere, Tunisia"
+                      },
+                      "raceType": {
+                        "type": "object",
+                        "properties": {
+                          "description": {
+                            "type": "string",
+                            "example": "Road Race Type"
+                          },
+                          "id": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Road"
+                          }
+                        }
+                      },
+                      "raceTypeId": {
+                        "type": "number",
+                        "example": 1
+                      },
+                      "startDate": {
+                        "type": "string",
+                        "example": "2022-05-24"
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "endDate": null,
+                      "event": {
+                        "id": 34,
+                        "name": "Volta Ciclista a Teseney"
+                      },
+                      "eventId": 34,
+                      "id": 34,
+                      "location": "Tampere, Tunisia",
+                      "raceType": {
+                        "description": "Road Race Type",
+                        "id": 1,
+                        "name": "Road"
+                      },
+                      "raceTypeId": 1,
+                      "startDate": "2022-05-24"
+                    },
+                    {
+                      "endDate": null,
+                      "event": {
+                        "id": 38,
+                        "name": "Volta Ciclista a Shahdol"
+                      },
+                      "eventId": 38,
+                      "id": 38,
+                      "location": "Prague, Croatia",
+                      "raceType": {
+                        "description": "Road Race Type",
+                        "id": 1,
+                        "name": "Road"
+                      },
+                      "raceTypeId": 1,
+                      "startDate": "2021-03-07"
+                    }
+                  ]
+                },
+                "examples": {
+                  "a list of Races": {
+                    "value": [
+                      {
+                        "endDate": null,
+                        "event": {
+                          "id": 34,
+                          "name": "Volta Ciclista a Teseney"
+                        },
+                        "eventId": 34,
+                        "id": 34,
+                        "location": "Tampere, Tunisia",
+                        "raceType": {
+                          "description": "Road Race Type",
+                          "id": 1,
+                          "name": "Road"
+                        },
+                        "raceTypeId": 1,
+                        "startDate": "2022-05-24"
+                      },
+                      {
+                        "endDate": null,
+                        "event": {
+                          "id": 38,
+                          "name": "Volta Ciclista a Shahdol"
+                        },
+                        "eventId": 38,
+                        "id": 38,
+                        "location": "Prague, Croatia",
+                        "raceType": {
+                          "description": "Road Race Type",
+                          "id": 1,
+                          "name": "Road"
+                        },
+                        "raceTypeId": 1,
+                        "startDate": "2021-03-07"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -133,7 +330,147 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "a new Race",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:23:28 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/races"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "endDate": {
+                      "nullable": true,
+                      "example": null
+                    },
+                    "event": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number",
+                          "example": 508
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Killerwat Grass Crit"
+                        }
+                      }
+                    },
+                    "eventId": {
+                      "type": "number",
+                      "example": 508
+                    },
+                    "id": {
+                      "type": "number",
+                      "example": 507
+                    },
+                    "location": {
+                      "type": "string",
+                      "example": "Northfield, MA"
+                    },
+                    "raceType": {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                          "example": "Road Race Type"
+                        },
+                        "id": {
+                          "type": "number",
+                          "example": 1
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Road"
+                        }
+                      }
+                    },
+                    "raceTypeId": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "startDate": {
+                      "type": "string",
+                      "example": "2024-04-12"
+                    }
+                  }
+                },
+                "examples": {
+                  "a new Race": {
+                    "value": {
+                      "endDate": null,
+                      "event": {
+                        "id": 508,
+                        "name": "Killerwat Grass Crit"
+                      },
+                      "eventId": 508,
+                      "id": 507,
+                      "location": "Northfield, MA",
+                      "raceType": {
+                        "description": "Road Race Type",
+                        "id": 1,
+                        "name": "Road"
+                      },
+                      "raceTypeId": 1,
+                      "startDate": "2024-04-12"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -148,7 +485,1323 @@
         "operationId": "aListOfAllCategories",
         "responses": {
           "200": {
-            "description": ""
+            "description": "a list of all Categories",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:23:38 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/races/categories"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "example": "Gran Fondo age group from 1 to 13 for Men"
+                      },
+                      "disicpline": {
+                        "type": "string",
+                        "example": "Gran Fondo"
+                      },
+                      "id": {
+                        "type": "number",
+                        "example": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Men Under 14"
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "description": "Gran Fondo age group from 1 to 13 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 1,
+                      "name": "Men Under 14"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 30 to 34 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 2,
+                      "name": "Women 30-34"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 35 to 39 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 3,
+                      "name": "Women 35-39"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 30 to 34 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 4,
+                      "name": "Non Binary 30-34"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 35 to 39 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 5,
+                      "name": "Non Binary 35-39"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 25 to 29 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 6,
+                      "name": "Non Binary 25-29"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 35 to 39 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 7,
+                      "name": "Men 35-39"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 40 to 44 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 8,
+                      "name": "Men 40-44"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 30 to 34 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 9,
+                      "name": "Men 30-34"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 19 to 24 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 10,
+                      "name": "Men 19-24"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 50 to 54 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 11,
+                      "name": "Men 50-54"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 55 to 59 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 12,
+                      "name": "Women 55-59"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 14 to 16 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 13,
+                      "name": "Non Binary 14-16"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 40 to 44 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 14,
+                      "name": "Non Binary 40-44"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 60 to 64 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 15,
+                      "name": "Women 60-64"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 50 to 54 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 16,
+                      "name": "Women 50-54"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 55 to 59 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 17,
+                      "name": "Non Binary 55-59"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 64 to 69 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 18,
+                      "name": "Women 65-69"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 50 to 54 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 19,
+                      "name": "Non Binary 50-54"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 60 to 64 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 20,
+                      "name": "Men 60-64"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 45 to 49 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 21,
+                      "name": "Men 45-49"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 60 to 64 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 22,
+                      "name": "Non Binary 60-64"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 64 to 69 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 24,
+                      "name": "Non Binary 65-69"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 70 to 74 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 25,
+                      "name": "Women 70-74"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 45 to 49 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 27,
+                      "name": "Women 45-49"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 70 to 74 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 29,
+                      "name": "Non Binary 70-74"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 75 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 33,
+                      "name": "Women 75 and Over"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 22 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 38,
+                      "name": "Non Binary Under 23"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 43,
+                      "name": "Men Open"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 35 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 49,
+                      "name": "Women 35+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 45 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 54,
+                      "name": "Women 45+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 60 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 62,
+                      "name": "Men 60+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 70 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 66,
+                      "name": "Women 70+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 70 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 73,
+                      "name": "Men 70+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 81,
+                      "name": "Women Cat 1"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 17 to 18 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 88,
+                      "name": "Women 17-18"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 90,
+                      "name": "Men Cat 3"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 98,
+                      "name": "Non Binary Novice"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 40 to 44 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 102,
+                      "name": "Women 40-44"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 14 to 16 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 23,
+                      "name": "Women 14-16"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 55 to 59 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 26,
+                      "name": "Men 55-59"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 64 to 69 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 28,
+                      "name": "Men 65-69"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 70 to 74 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 31,
+                      "name": "Men 70-74"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 75 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 34,
+                      "name": "Men 75 and Over"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 37,
+                      "name": "Non Binary Open"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 22 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 42,
+                      "name": "Men Under 23"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 17 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 48,
+                      "name": "Men Juniors"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 35 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 56,
+                      "name": "Men 35+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 55 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 60,
+                      "name": "Men 55+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 50 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 70,
+                      "name": "Non Binary 50+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 76,
+                      "name": "Men Cat 1"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 86,
+                      "name": "Non Binary Cat 2"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 92,
+                      "name": "Non Binary Pro"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 13 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 30,
+                      "name": "Women Under 14"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 17 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 35,
+                      "name": "Non Binary Juniors"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 75 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 39,
+                      "name": "Non Binary 75 and Over"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 30 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 45,
+                      "name": "Non Binary 30+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 22 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 50,
+                      "name": "Women Under 23"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 40 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 57,
+                      "name": "Men 40+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 50 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 63,
+                      "name": "Women 50+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 60 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 69,
+                      "name": "Non Binary 60+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 79,
+                      "name": "Non Binary Cat 1"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 87,
+                      "name": "Women Cat 3"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 96,
+                      "name": "Men Novice"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 17 to 18 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 32,
+                      "name": "Men 17-18"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 45 to 49 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 36,
+                      "name": "Non Binary 45-49"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 30 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 41,
+                      "name": "Men 30+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 47,
+                      "name": "Women Open"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 35 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 51,
+                      "name": "Non Binary 35+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 40 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 58,
+                      "name": "Non Binary 40+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 45 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 64,
+                      "name": "Men 45+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 80 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 72,
+                      "name": "Non Binary 80+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 78,
+                      "name": "Men Pro"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 84,
+                      "name": "Women Cat 2"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 97,
+                      "name": "Non Binary Cat 4"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 14 to 16 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 100,
+                      "name": "Men 14-16"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 19 to 24 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 40,
+                      "name": "Women 19-24"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 30 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 46,
+                      "name": "Women 30+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 40 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 55,
+                      "name": "Women 40+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 45 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 61,
+                      "name": "Non Binary 45+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 55 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 68,
+                      "name": "Women 55+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 80 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 77,
+                      "name": "Women 80+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 85,
+                      "name": "Women Pro"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 91,
+                      "name": "Men Cat 4"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 25 to 29 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 44,
+                      "name": "Women 25-29"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 17 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 53,
+                      "name": "Women Juniors"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 55 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 59,
+                      "name": "Non Binary 55+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 60 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 67,
+                      "name": "Women 60+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 70 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 74,
+                      "name": "Non Binary 70+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 83,
+                      "name": "Non Binary Pro"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 94,
+                      "name": "Non Binary Cat 3"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 25 to 29 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 99,
+                      "name": "Men 25-29"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 17 to 18 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 52,
+                      "name": "Non Binary 17-18"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 50 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 65,
+                      "name": "Men 50+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 80 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 71,
+                      "name": "Men 80+"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 75,
+                      "name": "Women Pro"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 82,
+                      "name": "Men Pro"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 95,
+                      "name": "Women Cat 4"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 19 to 24 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 101,
+                      "name": "Non Binary 19-24"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 13 for Non Binary",
+                      "disicpline": "Gran Fondo",
+                      "id": 80,
+                      "name": "Non Binary Under 14"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Men",
+                      "disicpline": "Gran Fondo",
+                      "id": 89,
+                      "name": "Men Cat 2"
+                    },
+                    {
+                      "description": "Gran Fondo age group from 1 to 999 for Women",
+                      "disicpline": "Gran Fondo",
+                      "id": 93,
+                      "name": "Women Novice"
+                    }
+                  ]
+                },
+                "examples": {
+                  "a list of all Categories": {
+                    "value": [
+                      {
+                        "description": "Gran Fondo age group from 1 to 13 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 1,
+                        "name": "Men Under 14"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 30 to 34 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 2,
+                        "name": "Women 30-34"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 35 to 39 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 3,
+                        "name": "Women 35-39"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 30 to 34 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 4,
+                        "name": "Non Binary 30-34"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 35 to 39 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 5,
+                        "name": "Non Binary 35-39"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 25 to 29 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 6,
+                        "name": "Non Binary 25-29"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 35 to 39 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 7,
+                        "name": "Men 35-39"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 40 to 44 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 8,
+                        "name": "Men 40-44"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 30 to 34 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 9,
+                        "name": "Men 30-34"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 19 to 24 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 10,
+                        "name": "Men 19-24"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 50 to 54 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 11,
+                        "name": "Men 50-54"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 55 to 59 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 12,
+                        "name": "Women 55-59"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 14 to 16 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 13,
+                        "name": "Non Binary 14-16"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 40 to 44 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 14,
+                        "name": "Non Binary 40-44"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 60 to 64 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 15,
+                        "name": "Women 60-64"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 50 to 54 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 16,
+                        "name": "Women 50-54"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 55 to 59 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 17,
+                        "name": "Non Binary 55-59"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 64 to 69 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 18,
+                        "name": "Women 65-69"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 50 to 54 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 19,
+                        "name": "Non Binary 50-54"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 60 to 64 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 20,
+                        "name": "Men 60-64"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 45 to 49 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 21,
+                        "name": "Men 45-49"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 60 to 64 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 22,
+                        "name": "Non Binary 60-64"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 64 to 69 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 24,
+                        "name": "Non Binary 65-69"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 70 to 74 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 25,
+                        "name": "Women 70-74"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 45 to 49 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 27,
+                        "name": "Women 45-49"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 70 to 74 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 29,
+                        "name": "Non Binary 70-74"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 75 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 33,
+                        "name": "Women 75 and Over"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 22 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 38,
+                        "name": "Non Binary Under 23"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 43,
+                        "name": "Men Open"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 35 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 49,
+                        "name": "Women 35+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 45 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 54,
+                        "name": "Women 45+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 60 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 62,
+                        "name": "Men 60+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 70 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 66,
+                        "name": "Women 70+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 70 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 73,
+                        "name": "Men 70+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 81,
+                        "name": "Women Cat 1"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 17 to 18 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 88,
+                        "name": "Women 17-18"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 90,
+                        "name": "Men Cat 3"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 98,
+                        "name": "Non Binary Novice"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 40 to 44 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 102,
+                        "name": "Women 40-44"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 14 to 16 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 23,
+                        "name": "Women 14-16"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 55 to 59 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 26,
+                        "name": "Men 55-59"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 64 to 69 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 28,
+                        "name": "Men 65-69"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 70 to 74 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 31,
+                        "name": "Men 70-74"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 75 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 34,
+                        "name": "Men 75 and Over"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 37,
+                        "name": "Non Binary Open"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 22 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 42,
+                        "name": "Men Under 23"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 17 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 48,
+                        "name": "Men Juniors"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 35 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 56,
+                        "name": "Men 35+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 55 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 60,
+                        "name": "Men 55+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 50 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 70,
+                        "name": "Non Binary 50+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 76,
+                        "name": "Men Cat 1"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 86,
+                        "name": "Non Binary Cat 2"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 92,
+                        "name": "Non Binary Pro"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 13 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 30,
+                        "name": "Women Under 14"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 17 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 35,
+                        "name": "Non Binary Juniors"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 75 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 39,
+                        "name": "Non Binary 75 and Over"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 30 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 45,
+                        "name": "Non Binary 30+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 22 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 50,
+                        "name": "Women Under 23"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 40 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 57,
+                        "name": "Men 40+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 50 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 63,
+                        "name": "Women 50+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 60 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 69,
+                        "name": "Non Binary 60+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 79,
+                        "name": "Non Binary Cat 1"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 87,
+                        "name": "Women Cat 3"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 96,
+                        "name": "Men Novice"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 17 to 18 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 32,
+                        "name": "Men 17-18"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 45 to 49 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 36,
+                        "name": "Non Binary 45-49"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 30 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 41,
+                        "name": "Men 30+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 47,
+                        "name": "Women Open"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 35 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 51,
+                        "name": "Non Binary 35+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 40 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 58,
+                        "name": "Non Binary 40+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 45 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 64,
+                        "name": "Men 45+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 80 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 72,
+                        "name": "Non Binary 80+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 78,
+                        "name": "Men Pro"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 84,
+                        "name": "Women Cat 2"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 97,
+                        "name": "Non Binary Cat 4"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 14 to 16 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 100,
+                        "name": "Men 14-16"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 19 to 24 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 40,
+                        "name": "Women 19-24"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 30 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 46,
+                        "name": "Women 30+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 40 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 55,
+                        "name": "Women 40+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 45 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 61,
+                        "name": "Non Binary 45+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 55 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 68,
+                        "name": "Women 55+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 80 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 77,
+                        "name": "Women 80+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 85,
+                        "name": "Women Pro"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 91,
+                        "name": "Men Cat 4"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 25 to 29 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 44,
+                        "name": "Women 25-29"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 17 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 53,
+                        "name": "Women Juniors"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 55 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 59,
+                        "name": "Non Binary 55+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 60 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 67,
+                        "name": "Women 60+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 70 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 74,
+                        "name": "Non Binary 70+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 83,
+                        "name": "Non Binary Pro"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 94,
+                        "name": "Non Binary Cat 3"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 25 to 29 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 99,
+                        "name": "Men 25-29"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 17 to 18 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 52,
+                        "name": "Non Binary 17-18"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 50 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 65,
+                        "name": "Men 50+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 80 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 71,
+                        "name": "Men 80+"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 75,
+                        "name": "Women Pro"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 82,
+                        "name": "Men Pro"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 95,
+                        "name": "Women Cat 4"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 19 to 24 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 101,
+                        "name": "Non Binary 19-24"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 13 for Non Binary",
+                        "disicpline": "Gran Fondo",
+                        "id": 80,
+                        "name": "Non Binary Under 14"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Men",
+                        "disicpline": "Gran Fondo",
+                        "id": 89,
+                        "name": "Men Cat 2"
+                      },
+                      {
+                        "description": "Gran Fondo age group from 1 to 999 for Women",
+                        "disicpline": "Gran Fondo",
+                        "id": 93,
+                        "name": "Women Novice"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -192,7 +1845,175 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "a total count of Races and Results",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:23:50 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/races/totals?from=2024-01-01&to=2024-09-01&groupby=month"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "startDate": {
+                        "type": "string",
+                        "example": "2024-01-01T05:00:00.000Z"
+                      },
+                      "totalRaces": {
+                        "type": "number",
+                        "example": 6
+                      },
+                      "totalRiders": {
+                        "type": "number",
+                        "example": 205
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "startDate": "2024-01-01T05:00:00.000Z",
+                      "totalRaces": 6,
+                      "totalRiders": 205
+                    },
+                    {
+                      "startDate": "2024-02-01T05:00:00.000Z",
+                      "totalRaces": 11,
+                      "totalRiders": 379
+                    },
+                    {
+                      "startDate": "2024-03-01T05:00:00.000Z",
+                      "totalRaces": 8,
+                      "totalRiders": 272
+                    },
+                    {
+                      "startDate": "2024-04-01T04:00:00.000Z",
+                      "totalRaces": 14,
+                      "totalRiders": 315
+                    },
+                    {
+                      "startDate": "2024-05-01T04:00:00.000Z",
+                      "totalRaces": 1,
+                      "totalRiders": 37
+                    },
+                    {
+                      "startDate": "2024-06-01T04:00:00.000Z",
+                      "totalRaces": 6,
+                      "totalRiders": 203
+                    },
+                    {
+                      "startDate": "2024-07-01T04:00:00.000Z",
+                      "totalRaces": 9,
+                      "totalRiders": 300
+                    },
+                    {
+                      "startDate": "2024-08-01T04:00:00.000Z",
+                      "totalRaces": 11,
+                      "totalRiders": 385
+                    }
+                  ]
+                },
+                "examples": {
+                  "a total count of Races and Results": {
+                    "value": [
+                      {
+                        "startDate": "2024-01-01T05:00:00.000Z",
+                        "totalRaces": 6,
+                        "totalRiders": 205
+                      },
+                      {
+                        "startDate": "2024-02-01T05:00:00.000Z",
+                        "totalRaces": 11,
+                        "totalRiders": 379
+                      },
+                      {
+                        "startDate": "2024-03-01T05:00:00.000Z",
+                        "totalRaces": 8,
+                        "totalRiders": 272
+                      },
+                      {
+                        "startDate": "2024-04-01T04:00:00.000Z",
+                        "totalRaces": 14,
+                        "totalRiders": 315
+                      },
+                      {
+                        "startDate": "2024-05-01T04:00:00.000Z",
+                        "totalRaces": 1,
+                        "totalRiders": 37
+                      },
+                      {
+                        "startDate": "2024-06-01T04:00:00.000Z",
+                        "totalRaces": 6,
+                        "totalRiders": 203
+                      },
+                      {
+                        "startDate": "2024-07-01T04:00:00.000Z",
+                        "totalRaces": 9,
+                        "totalRiders": 300
+                      },
+                      {
+                        "startDate": "2024-08-01T04:00:00.000Z",
+                        "totalRaces": 11,
+                        "totalRiders": 385
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -207,7 +2028,4123 @@
         "operationId": "aListOfResultsForASingleRace",
         "responses": {
           "200": {
-            "description": ""
+            "description": "a list of Results for a single Race",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:24:09 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/races/5/results"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "type": "object",
+                        "properties": {
+                          "Race": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "endDate": {
+                                  "nullable": true,
+                                  "example": null
+                                },
+                                "eventId": {
+                                  "type": "number",
+                                  "example": 5
+                                },
+                                "id": {
+                                  "type": "number",
+                                  "example": 5
+                                },
+                                "location": {
+                                  "type": "string",
+                                  "example": "Antalya, Lithuania"
+                                },
+                                "raceType": {
+                                  "type": "object",
+                                  "properties": {
+                                    "description": {
+                                      "type": "string",
+                                      "example": "Road Race Type"
+                                    },
+                                    "id": {
+                                      "type": "number",
+                                      "example": 1
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "example": "Road"
+                                    }
+                                  }
+                                },
+                                "raceTypeId": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "startDate": {
+                                  "type": "string",
+                                  "example": "2021-06-27"
+                                }
+                              }
+                            },
+                            "example": [
+                              {
+                                "endDate": null,
+                                "eventId": 5,
+                                "id": 5,
+                                "location": "Antalya, Lithuania",
+                                "raceType": {
+                                  "description": "Road Race Type",
+                                  "id": 1,
+                                  "name": "Road"
+                                },
+                                "raceTypeId": 1,
+                                "startDate": "2021-06-27"
+                              }
+                            ]
+                          },
+                          "id": {
+                            "type": "number",
+                            "example": 5
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Dao Timmi Shahdol"
+                          }
+                        }
+                      },
+                      "eventId": {
+                        "type": "number",
+                        "example": 5
+                      },
+                      "id": {
+                        "type": "number",
+                        "example": 152
+                      },
+                      "lap": {
+                        "nullable": true,
+                        "example": null
+                      },
+                      "noPlaceCodeType": {
+                        "type": "object",
+                        "properties": {
+                          "description": {
+                            "type": "string",
+                            "example": "Participant Placed"
+                          },
+                          "id": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "NA"
+                          }
+                        }
+                      },
+                      "noPlaceCodeTypeId": {
+                        "type": "number",
+                        "example": 1
+                      },
+                      "place": {
+                        "type": "number",
+                        "example": 1
+                      },
+                      "points": {
+                        "type": "number",
+                        "example": 115
+                      },
+                      "resultType": {
+                        "type": "object",
+                        "properties": {
+                          "description": {
+                            "type": "string",
+                            "example": "Default Result Type"
+                          },
+                          "id": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "default"
+                          }
+                        }
+                      },
+                      "resultTypeId": {
+                        "type": "number",
+                        "example": 1
+                      },
+                      "rider": {
+                        "type": "object",
+                        "properties": {
+                          "about": {
+                            "type": "string",
+                            "example": "They think I'm just some dumb hick. They said that to me, at a dinner!"
+                          },
+                          "country": {
+                            "type": "string",
+                            "example": "Ukraine"
+                          },
+                          "dob": {
+                            "type": "string",
+                            "example": "Mon Jan 15 2001"
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "example": "Spedvagon"
+                          },
+                          "hometown": {
+                            "type": "string",
+                            "example": "Chiang Mai"
+                          },
+                          "id": {
+                            "type": "number",
+                            "example": 19
+                          },
+                          "insta": {
+                            "type": "string",
+                            "example": "pl"
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "example": "De Minus"
+                          },
+                          "photo": {
+                            "type": "string",
+                            "example": "https://www.procyclingstats.com/images/riders/bp/ec/florian-senechal-2024.jpg"
+                          },
+                          "strava": {
+                            "type": "string",
+                            "example": "996863"
+                          }
+                        }
+                      },
+                      "riderId": {
+                        "type": "number",
+                        "example": 19
+                      },
+                      "time": {
+                        "type": "string",
+                        "example": ""
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 152,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 1,
+                      "points": 115,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Ukraine",
+                        "dob": "Mon Jan 15 2001",
+                        "firstName": "Spedvagon",
+                        "hometown": "Chiang Mai",
+                        "id": 19,
+                        "insta": "pl",
+                        "lastName": "De Minus",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ec/florian-senechal-2024.jpg",
+                        "strava": "996863"
+                      },
+                      "riderId": 19,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 161,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 4,
+                      "points": 70,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Australia",
+                        "dob": "Thu Jul 12 1990",
+                        "firstName": "Biniam",
+                        "hometown": "Metz",
+                        "id": 17,
+                        "insta": "na",
+                        "lastName": "McRothair",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ff/lorena-wiebes-2024-n2.jpeg",
+                        "strava": "4708197"
+                      },
+                      "riderId": 17,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 170,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 19,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Norway",
+                        "dob": "Wed Jan 09 1985",
+                        "firstName": "Magnus",
+                        "hometown": "Uddevella",
+                        "id": 41,
+                        "insta": "zovqkuqdqpqazl",
+                        "lastName": "Ghekiere",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg",
+                        "strava": "9645046"
+                      },
+                      "riderId": 41,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 179,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 2,
+                      "points": 100,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Guatemala",
+                        "dob": "Wed May 09 1984",
+                        "firstName": "Murbo",
+                        "hometown": "Cordoba",
+                        "id": 24,
+                        "insta": "agifgzyfzoqhx",
+                        "lastName": "Barder",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg",
+                        "strava": "1266622"
+                      },
+                      "riderId": 24,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 144,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 33,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Norway",
+                        "dob": "Wed Aug 30 1995",
+                        "firstName": "Katarzyna",
+                        "hometown": "Zagreb",
+                        "id": 8,
+                        "insta": "nkwl",
+                        "lastName": "Paceclim",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                        "strava": "6701426"
+                      },
+                      "riderId": 8,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 153,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 37,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Puerto Rico",
+                        "dob": "Fri May 18 1990",
+                        "firstName": "Mathieu",
+                        "hometown": "Hoi An",
+                        "id": 20,
+                        "insta": "qtm",
+                        "lastName": "Cornt",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/fb/kasper-asgreen-2024.jpeg",
+                        "strava": "4682464"
+                      },
+                      "riderId": 20,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 162,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 27,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Greece",
+                        "dob": "Thu Aug 24 2006",
+                        "firstName": "Xandro",
+                        "hometown": "Reykjavik",
+                        "id": 34,
+                        "insta": "llcuzaagyc",
+                        "lastName": "Sormano",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg",
+                        "strava": "6278699"
+                      },
+                      "riderId": 34,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 171,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 28,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Jordan",
+                        "dob": "Tue Feb 15 2005",
+                        "firstName": "Xandro",
+                        "hometown": "Metz",
+                        "id": 28,
+                        "insta": "jldyumobpgwcp",
+                        "lastName": "Terravelo",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/aa/remco-evenepoel-2024.jpeg",
+                        "strava": "8189011"
+                      },
+                      "riderId": 28,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 180,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 10,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Wales",
+                        "dob": "Mon Mar 27 2006",
+                        "firstName": "Marte",
+                        "hometown": "Reykjavik",
+                        "id": 39,
+                        "insta": "fgt",
+                        "lastName": "Rickymas",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                        "strava": "9912067"
+                      },
+                      "riderId": 39,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 150,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 8,
+                      "points": 10,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Belarus",
+                        "dob": "Tue May 06 1997",
+                        "firstName": "Matej",
+                        "hometown": "Asmara",
+                        "id": 16,
+                        "insta": "z",
+                        "lastName": "Kamna",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/cc/rigoberto-uran-2024.jpeg",
+                        "strava": "8372609"
+                      },
+                      "riderId": 16,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 160,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 31,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Norway",
+                        "dob": "Fri May 18 2001",
+                        "firstName": "Dynamo",
+                        "hometown": "Rijeka",
+                        "id": 31,
+                        "insta": "wieajqaxc",
+                        "lastName": "Torqueheed",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                        "strava": "3172617"
+                      },
+                      "riderId": 31,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 168,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 26,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Panama",
+                        "dob": "Mon Jan 31 2005",
+                        "firstName": "Geraint",
+                        "hometown": "Tibooburra",
+                        "id": 38,
+                        "insta": "juhxht",
+                        "lastName": "Alafilippo",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg",
+                        "strava": "4181190"
+                      },
+                      "riderId": 38,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 177,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 30,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Chile",
+                        "dob": "Sun Jul 21 1991",
+                        "firstName": "Demi",
+                        "hometown": "Prague",
+                        "id": 25,
+                        "insta": "hulmdau",
+                        "lastName": "Squiban",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg",
+                        "strava": "6696292"
+                      },
+                      "riderId": 25,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 151,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 11,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Peru",
+                        "dob": "Fri Nov 15 1991",
+                        "firstName": "Mattias",
+                        "hometown": "Vimmerby",
+                        "id": 11,
+                        "insta": "fiesujbkwk",
+                        "lastName": "McRothair",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/bd/merhawi-kudus-2024.png",
+                        "strava": "6361228"
+                      },
+                      "riderId": 11,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 156,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 9,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Scotland",
+                        "dob": "Mon Apr 23 1984",
+                        "firstName": "Zephyr",
+                        "hometown": "Broken Hill",
+                        "id": 32,
+                        "insta": "xvcyvkovdic",
+                        "lastName": "Tourbolet",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/fa/michael-morkov-2024.jpg",
+                        "strava": "1591863"
+                      },
+                      "riderId": 32,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 165,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 7,
+                      "points": 25,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Puerto Rico",
+                        "dob": "Sat Oct 20 1984",
+                        "firstName": "Sepp",
+                        "hometown": "Passe de Kourizo",
+                        "id": 15,
+                        "insta": "oedhxommck",
+                        "lastName": "Markrus",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg",
+                        "strava": "9797010"
+                      },
+                      "riderId": 15,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 178,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 35,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Estonia",
+                        "dob": "Sat Aug 27 1988",
+                        "firstName": "Mattias",
+                        "hometown": "Grenada",
+                        "id": 29,
+                        "insta": "aquzntsg",
+                        "lastName": "Siverkov",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/fc/lotte-kopecky-2024-n2.jpeg",
+                        "strava": "3054718"
+                      },
+                      "riderId": 29,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 148,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 16,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Croatia",
+                        "dob": "Thu Feb 27 1986",
+                        "firstName": "Thalita",
+                        "hometown": "Fox Glacier",
+                        "id": 9,
+                        "insta": "ndrgahaxqungq",
+                        "lastName": "Van Vleumower",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/dd/geraint-thomas-2024.jpg",
+                        "strava": "1619538"
+                      },
+                      "riderId": 9,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 155,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 20,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Indonesia",
+                        "dob": "Mon Mar 02 1987",
+                        "firstName": "Filippo",
+                        "hometown": "Rijeka",
+                        "id": 26,
+                        "insta": "gdxyfxuiyrghvn",
+                        "lastName": "Paceclim",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                        "strava": "4358756"
+                      },
+                      "riderId": 26,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 164,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 17,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Slovenia",
+                        "dob": "Wed Sep 28 2005",
+                        "firstName": "Enric",
+                        "hometown": "Tampere",
+                        "id": 36,
+                        "insta": "axde",
+                        "lastName": "Giauman",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ce/grace-brown-2022-n2.jpg",
+                        "strava": "9281875"
+                      },
+                      "riderId": 36,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 175,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 34,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Sweden",
+                        "dob": "Sat Jun 05 2004",
+                        "firstName": "Harold",
+                        "hometown": "Seoni",
+                        "id": 35,
+                        "insta": "efatihvkf",
+                        "lastName": "Koolkoolkool",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg",
+                        "strava": "4893701"
+                      },
+                      "riderId": 35,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 145,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 3,
+                      "points": 85,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Greece",
+                        "dob": "Fri Nov 05 1999",
+                        "firstName": "Katarzyna",
+                        "hometown": "Malaga",
+                        "id": 13,
+                        "insta": "n",
+                        "lastName": "Lancia-pneumatici",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/dd/geraint-thomas-2024.jpg",
+                        "strava": "4413982"
+                      },
+                      "riderId": 13,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 154,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 36,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Scotland",
+                        "dob": "Thu Oct 19 2000",
+                        "firstName": "Jhonatan",
+                        "hometown": "Flinders Rangers",
+                        "id": 22,
+                        "insta": "vfsohk",
+                        "lastName": "Cuss",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ae/marianne-vos-2024.png",
+                        "strava": "7086712"
+                      },
+                      "riderId": 22,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 163,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 32,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Hungary",
+                        "dob": "Tue Oct 21 2003",
+                        "firstName": "Zestnor",
+                        "hometown": "Burlington",
+                        "id": 12,
+                        "insta": "gxwlqavyphohkc",
+                        "lastName": "Galb",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg",
+                        "strava": "3226592"
+                      },
+                      "riderId": 12,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 172,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 13,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Kenya",
+                        "dob": "Mon Jun 04 1990",
+                        "firstName": "Matteo",
+                        "hometown": "Florence",
+                        "id": 42,
+                        "insta": "tjv",
+                        "lastName": "Arrow",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/bd/marc-soler-2024-n2.jpeg",
+                        "strava": "127532"
+                      },
+                      "riderId": 42,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 146,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 12,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Burundi",
+                        "dob": "Thu Mar 09 2006",
+                        "firstName": "Xandro",
+                        "hometown": "Hamburg",
+                        "id": 21,
+                        "insta": "c",
+                        "lastName": "Chabbo",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/dc/ben-healy-2024.jpeg",
+                        "strava": "7355646"
+                      },
+                      "riderId": 21,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 159,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 15,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Lithuania",
+                        "dob": "Sun Nov 14 1993",
+                        "firstName": "Fem",
+                        "hometown": "Bled",
+                        "id": 33,
+                        "insta": "zxgmcqzzzme",
+                        "lastName": "Johanndort",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/cf/amber-kraak-2024.jpg",
+                        "strava": "2005234"
+                      },
+                      "riderId": 33,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 166,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 18,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Bulgaria",
+                        "dob": "Fri Oct 01 2004",
+                        "firstName": "Sonic",
+                        "hometown": "Dublin",
+                        "id": 40,
+                        "insta": "utmhbermbmzgar",
+                        "lastName": "Rowerowski",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg",
+                        "strava": "9902889"
+                      },
+                      "riderId": 40,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 174,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 29,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Panama",
+                        "dob": "Sat Jul 07 1990",
+                        "firstName": "Antonia",
+                        "hometown": "Burlington",
+                        "id": 43,
+                        "insta": "phpo",
+                        "lastName": "Ciccolo",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/fa/michael-morkov-2024.jpg",
+                        "strava": "298111"
+                      },
+                      "riderId": 43,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 147,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 21,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Malaysia",
+                        "dob": "Fri Aug 22 2003",
+                        "firstName": "Harold",
+                        "hometown": "Dao Timmi",
+                        "id": 14,
+                        "insta": "gkweanhw",
+                        "lastName": "Vons",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg",
+                        "strava": "6623078"
+                      },
+                      "riderId": 14,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 158,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 6,
+                      "points": 40,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Peru",
+                        "dob": "Tue Mar 01 1994",
+                        "firstName": "Cecilie",
+                        "hometown": "Broken Hill",
+                        "id": 27,
+                        "insta": "ckhoqbgvmbhkfbp",
+                        "lastName": "Gavia",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ab/tobias-halland-johannessen-2024.png",
+                        "strava": "2461522"
+                      },
+                      "riderId": 27,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 167,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 14,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Wales",
+                        "dob": "Mon May 12 1997",
+                        "firstName": "Cecilie",
+                        "hometown": "Ulsan",
+                        "id": 23,
+                        "insta": "mteheltvajsgkfn",
+                        "lastName": "Gamma",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg",
+                        "strava": "1162576"
+                      },
+                      "riderId": 23,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 173,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 24,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Germany",
+                        "dob": "Thu Feb 26 2004",
+                        "firstName": "Katarzyna",
+                        "hometown": "Brussels",
+                        "id": 18,
+                        "insta": "dvzhiwiecarrgzj",
+                        "lastName": "Kamna",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                        "strava": "353540"
+                      },
+                      "riderId": 18,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 149,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 25,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Croatia",
+                        "dob": "Sun Aug 05 2001",
+                        "firstName": "Harold",
+                        "hometown": "Dao Timmi",
+                        "id": 10,
+                        "insta": "fclhne",
+                        "lastName": "Gamma",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/cc/rigoberto-uran-2024.jpeg",
+                        "strava": "7898112"
+                      },
+                      "riderId": 10,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 157,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 22,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "UK",
+                        "dob": "Wed Mar 29 2000",
+                        "firstName": "Nielson",
+                        "hometown": "Dublin",
+                        "id": 30,
+                        "insta": "qokpuhzkyxgf",
+                        "lastName": "Tacktheritrix",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg",
+                        "strava": "5447158"
+                      },
+                      "riderId": 30,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 169,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 23,
+                      "points": 0,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Nicaragua",
+                        "dob": "Tue Feb 06 1990",
+                        "firstName": "Thymen",
+                        "hometown": "Debark",
+                        "id": 37,
+                        "insta": "aoylnn",
+                        "lastName": "Madyuas",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/ea/alberto-bettiol-2024-n2-n3.jpg",
+                        "strava": "7899573"
+                      },
+                      "riderId": 37,
+                      "time": ""
+                    },
+                    {
+                      "event": {
+                        "Race": [
+                          {
+                            "endDate": null,
+                            "eventId": 5,
+                            "id": 5,
+                            "location": "Antalya, Lithuania",
+                            "raceType": {
+                              "description": "Road Race Type",
+                              "id": 1,
+                              "name": "Road"
+                            },
+                            "raceTypeId": 1,
+                            "startDate": "2021-06-27"
+                          }
+                        ],
+                        "id": 5,
+                        "name": "Dao Timmi Shahdol"
+                      },
+                      "eventId": 5,
+                      "id": 176,
+                      "lap": null,
+                      "noPlaceCodeType": {
+                        "description": "Participant Placed",
+                        "id": 1,
+                        "name": "NA"
+                      },
+                      "noPlaceCodeTypeId": 1,
+                      "place": 5,
+                      "points": 55,
+                      "resultType": {
+                        "description": "Default Result Type",
+                        "id": 1,
+                        "name": "default"
+                      },
+                      "resultTypeId": 1,
+                      "rider": {
+                        "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                        "country": "Greece",
+                        "dob": "Sun Jan 14 2001",
+                        "firstName": "Cyclistopher",
+                        "hometown": "Mildura",
+                        "id": 44,
+                        "insta": "hxutcmnydtyyiih",
+                        "lastName": "Velocepede",
+                        "photo": "https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg",
+                        "strava": "9209250"
+                      },
+                      "riderId": 44,
+                      "time": ""
+                    }
+                  ]
+                },
+                "examples": {
+                  "a list of Results for a single Race": {
+                    "value": [
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 152,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 1,
+                        "points": 115,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Ukraine",
+                          "dob": "Mon Jan 15 2001",
+                          "firstName": "Spedvagon",
+                          "hometown": "Chiang Mai",
+                          "id": 19,
+                          "insta": "pl",
+                          "lastName": "De Minus",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ec/florian-senechal-2024.jpg",
+                          "strava": "996863"
+                        },
+                        "riderId": 19,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 161,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 4,
+                        "points": 70,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Australia",
+                          "dob": "Thu Jul 12 1990",
+                          "firstName": "Biniam",
+                          "hometown": "Metz",
+                          "id": 17,
+                          "insta": "na",
+                          "lastName": "McRothair",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ff/lorena-wiebes-2024-n2.jpeg",
+                          "strava": "4708197"
+                        },
+                        "riderId": 17,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 170,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 19,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Norway",
+                          "dob": "Wed Jan 09 1985",
+                          "firstName": "Magnus",
+                          "hometown": "Uddevella",
+                          "id": 41,
+                          "insta": "zovqkuqdqpqazl",
+                          "lastName": "Ghekiere",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg",
+                          "strava": "9645046"
+                        },
+                        "riderId": 41,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 179,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 2,
+                        "points": 100,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Guatemala",
+                          "dob": "Wed May 09 1984",
+                          "firstName": "Murbo",
+                          "hometown": "Cordoba",
+                          "id": 24,
+                          "insta": "agifgzyfzoqhx",
+                          "lastName": "Barder",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg",
+                          "strava": "1266622"
+                        },
+                        "riderId": 24,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 144,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 33,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Norway",
+                          "dob": "Wed Aug 30 1995",
+                          "firstName": "Katarzyna",
+                          "hometown": "Zagreb",
+                          "id": 8,
+                          "insta": "nkwl",
+                          "lastName": "Paceclim",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                          "strava": "6701426"
+                        },
+                        "riderId": 8,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 153,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 37,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Puerto Rico",
+                          "dob": "Fri May 18 1990",
+                          "firstName": "Mathieu",
+                          "hometown": "Hoi An",
+                          "id": 20,
+                          "insta": "qtm",
+                          "lastName": "Cornt",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/fb/kasper-asgreen-2024.jpeg",
+                          "strava": "4682464"
+                        },
+                        "riderId": 20,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 162,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 27,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Greece",
+                          "dob": "Thu Aug 24 2006",
+                          "firstName": "Xandro",
+                          "hometown": "Reykjavik",
+                          "id": 34,
+                          "insta": "llcuzaagyc",
+                          "lastName": "Sormano",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg",
+                          "strava": "6278699"
+                        },
+                        "riderId": 34,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 171,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 28,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Jordan",
+                          "dob": "Tue Feb 15 2005",
+                          "firstName": "Xandro",
+                          "hometown": "Metz",
+                          "id": 28,
+                          "insta": "jldyumobpgwcp",
+                          "lastName": "Terravelo",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/aa/remco-evenepoel-2024.jpeg",
+                          "strava": "8189011"
+                        },
+                        "riderId": 28,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 180,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 10,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Wales",
+                          "dob": "Mon Mar 27 2006",
+                          "firstName": "Marte",
+                          "hometown": "Reykjavik",
+                          "id": 39,
+                          "insta": "fgt",
+                          "lastName": "Rickymas",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                          "strava": "9912067"
+                        },
+                        "riderId": 39,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 150,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 8,
+                        "points": 10,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Belarus",
+                          "dob": "Tue May 06 1997",
+                          "firstName": "Matej",
+                          "hometown": "Asmara",
+                          "id": 16,
+                          "insta": "z",
+                          "lastName": "Kamna",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/cc/rigoberto-uran-2024.jpeg",
+                          "strava": "8372609"
+                        },
+                        "riderId": 16,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 160,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 31,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Norway",
+                          "dob": "Fri May 18 2001",
+                          "firstName": "Dynamo",
+                          "hometown": "Rijeka",
+                          "id": 31,
+                          "insta": "wieajqaxc",
+                          "lastName": "Torqueheed",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                          "strava": "3172617"
+                        },
+                        "riderId": 31,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 168,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 26,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Panama",
+                          "dob": "Mon Jan 31 2005",
+                          "firstName": "Geraint",
+                          "hometown": "Tibooburra",
+                          "id": 38,
+                          "insta": "juhxht",
+                          "lastName": "Alafilippo",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg",
+                          "strava": "4181190"
+                        },
+                        "riderId": 38,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 177,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 30,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Chile",
+                          "dob": "Sun Jul 21 1991",
+                          "firstName": "Demi",
+                          "hometown": "Prague",
+                          "id": 25,
+                          "insta": "hulmdau",
+                          "lastName": "Squiban",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg",
+                          "strava": "6696292"
+                        },
+                        "riderId": 25,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 151,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 11,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Peru",
+                          "dob": "Fri Nov 15 1991",
+                          "firstName": "Mattias",
+                          "hometown": "Vimmerby",
+                          "id": 11,
+                          "insta": "fiesujbkwk",
+                          "lastName": "McRothair",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/bd/merhawi-kudus-2024.png",
+                          "strava": "6361228"
+                        },
+                        "riderId": 11,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 156,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 9,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Scotland",
+                          "dob": "Mon Apr 23 1984",
+                          "firstName": "Zephyr",
+                          "hometown": "Broken Hill",
+                          "id": 32,
+                          "insta": "xvcyvkovdic",
+                          "lastName": "Tourbolet",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/fa/michael-morkov-2024.jpg",
+                          "strava": "1591863"
+                        },
+                        "riderId": 32,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 165,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 7,
+                        "points": 25,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Puerto Rico",
+                          "dob": "Sat Oct 20 1984",
+                          "firstName": "Sepp",
+                          "hometown": "Passe de Kourizo",
+                          "id": 15,
+                          "insta": "oedhxommck",
+                          "lastName": "Markrus",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg",
+                          "strava": "9797010"
+                        },
+                        "riderId": 15,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 178,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 35,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Estonia",
+                          "dob": "Sat Aug 27 1988",
+                          "firstName": "Mattias",
+                          "hometown": "Grenada",
+                          "id": 29,
+                          "insta": "aquzntsg",
+                          "lastName": "Siverkov",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/fc/lotte-kopecky-2024-n2.jpeg",
+                          "strava": "3054718"
+                        },
+                        "riderId": 29,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 148,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 16,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Croatia",
+                          "dob": "Thu Feb 27 1986",
+                          "firstName": "Thalita",
+                          "hometown": "Fox Glacier",
+                          "id": 9,
+                          "insta": "ndrgahaxqungq",
+                          "lastName": "Van Vleumower",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/dd/geraint-thomas-2024.jpg",
+                          "strava": "1619538"
+                        },
+                        "riderId": 9,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 155,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 20,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Indonesia",
+                          "dob": "Mon Mar 02 1987",
+                          "firstName": "Filippo",
+                          "hometown": "Rijeka",
+                          "id": 26,
+                          "insta": "gdxyfxuiyrghvn",
+                          "lastName": "Paceclim",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                          "strava": "4358756"
+                        },
+                        "riderId": 26,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 164,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 17,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Slovenia",
+                          "dob": "Wed Sep 28 2005",
+                          "firstName": "Enric",
+                          "hometown": "Tampere",
+                          "id": 36,
+                          "insta": "axde",
+                          "lastName": "Giauman",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ce/grace-brown-2022-n2.jpg",
+                          "strava": "9281875"
+                        },
+                        "riderId": 36,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 175,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 34,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Sweden",
+                          "dob": "Sat Jun 05 2004",
+                          "firstName": "Harold",
+                          "hometown": "Seoni",
+                          "id": 35,
+                          "insta": "efatihvkf",
+                          "lastName": "Koolkoolkool",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg",
+                          "strava": "4893701"
+                        },
+                        "riderId": 35,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 145,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 3,
+                        "points": 85,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Greece",
+                          "dob": "Fri Nov 05 1999",
+                          "firstName": "Katarzyna",
+                          "hometown": "Malaga",
+                          "id": 13,
+                          "insta": "n",
+                          "lastName": "Lancia-pneumatici",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/dd/geraint-thomas-2024.jpg",
+                          "strava": "4413982"
+                        },
+                        "riderId": 13,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 154,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 36,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Scotland",
+                          "dob": "Thu Oct 19 2000",
+                          "firstName": "Jhonatan",
+                          "hometown": "Flinders Rangers",
+                          "id": 22,
+                          "insta": "vfsohk",
+                          "lastName": "Cuss",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ae/marianne-vos-2024.png",
+                          "strava": "7086712"
+                        },
+                        "riderId": 22,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 163,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 32,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Hungary",
+                          "dob": "Tue Oct 21 2003",
+                          "firstName": "Zestnor",
+                          "hometown": "Burlington",
+                          "id": 12,
+                          "insta": "gxwlqavyphohkc",
+                          "lastName": "Galb",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg",
+                          "strava": "3226592"
+                        },
+                        "riderId": 12,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 172,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 13,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Kenya",
+                          "dob": "Mon Jun 04 1990",
+                          "firstName": "Matteo",
+                          "hometown": "Florence",
+                          "id": 42,
+                          "insta": "tjv",
+                          "lastName": "Arrow",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/bd/marc-soler-2024-n2.jpeg",
+                          "strava": "127532"
+                        },
+                        "riderId": 42,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 146,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 12,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Burundi",
+                          "dob": "Thu Mar 09 2006",
+                          "firstName": "Xandro",
+                          "hometown": "Hamburg",
+                          "id": 21,
+                          "insta": "c",
+                          "lastName": "Chabbo",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/dc/ben-healy-2024.jpeg",
+                          "strava": "7355646"
+                        },
+                        "riderId": 21,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 159,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 15,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Lithuania",
+                          "dob": "Sun Nov 14 1993",
+                          "firstName": "Fem",
+                          "hometown": "Bled",
+                          "id": 33,
+                          "insta": "zxgmcqzzzme",
+                          "lastName": "Johanndort",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/cf/amber-kraak-2024.jpg",
+                          "strava": "2005234"
+                        },
+                        "riderId": 33,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 166,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 18,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Bulgaria",
+                          "dob": "Fri Oct 01 2004",
+                          "firstName": "Sonic",
+                          "hometown": "Dublin",
+                          "id": 40,
+                          "insta": "utmhbermbmzgar",
+                          "lastName": "Rowerowski",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg",
+                          "strava": "9902889"
+                        },
+                        "riderId": 40,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 174,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 29,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Panama",
+                          "dob": "Sat Jul 07 1990",
+                          "firstName": "Antonia",
+                          "hometown": "Burlington",
+                          "id": 43,
+                          "insta": "phpo",
+                          "lastName": "Ciccolo",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/fa/michael-morkov-2024.jpg",
+                          "strava": "298111"
+                        },
+                        "riderId": 43,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 147,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 21,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Malaysia",
+                          "dob": "Fri Aug 22 2003",
+                          "firstName": "Harold",
+                          "hometown": "Dao Timmi",
+                          "id": 14,
+                          "insta": "gkweanhw",
+                          "lastName": "Vons",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg",
+                          "strava": "6623078"
+                        },
+                        "riderId": 14,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 158,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 6,
+                        "points": 40,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Peru",
+                          "dob": "Tue Mar 01 1994",
+                          "firstName": "Cecilie",
+                          "hometown": "Broken Hill",
+                          "id": 27,
+                          "insta": "ckhoqbgvmbhkfbp",
+                          "lastName": "Gavia",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ab/tobias-halland-johannessen-2024.png",
+                          "strava": "2461522"
+                        },
+                        "riderId": 27,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 167,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 14,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Wales",
+                          "dob": "Mon May 12 1997",
+                          "firstName": "Cecilie",
+                          "hometown": "Ulsan",
+                          "id": 23,
+                          "insta": "mteheltvajsgkfn",
+                          "lastName": "Gamma",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ea/enric-mas-2024.jpeg",
+                          "strava": "1162576"
+                        },
+                        "riderId": 23,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 173,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 24,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Germany",
+                          "dob": "Thu Feb 26 2004",
+                          "firstName": "Katarzyna",
+                          "hometown": "Brussels",
+                          "id": 18,
+                          "insta": "dvzhiwiecarrgzj",
+                          "lastName": "Kamna",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/eb/mattia-cattaneo-2024.jpeg",
+                          "strava": "353540"
+                        },
+                        "riderId": 18,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 149,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 25,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Croatia",
+                          "dob": "Sun Aug 05 2001",
+                          "firstName": "Harold",
+                          "hometown": "Dao Timmi",
+                          "id": 10,
+                          "insta": "fclhne",
+                          "lastName": "Gamma",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/cc/rigoberto-uran-2024.jpeg",
+                          "strava": "7898112"
+                        },
+                        "riderId": 10,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 157,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 22,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "UK",
+                          "dob": "Wed Mar 29 2000",
+                          "firstName": "Nielson",
+                          "hometown": "Dublin",
+                          "id": 30,
+                          "insta": "qokpuhzkyxgf",
+                          "lastName": "Tacktheritrix",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/df/matteo-jorgenson-2024.jpeg",
+                          "strava": "5447158"
+                        },
+                        "riderId": 30,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 169,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 23,
+                        "points": 0,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Nicaragua",
+                          "dob": "Tue Feb 06 1990",
+                          "firstName": "Thymen",
+                          "hometown": "Debark",
+                          "id": 37,
+                          "insta": "aoylnn",
+                          "lastName": "Madyuas",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/ea/alberto-bettiol-2024-n2-n3.jpg",
+                          "strava": "7899573"
+                        },
+                        "riderId": 37,
+                        "time": ""
+                      },
+                      {
+                        "event": {
+                          "Race": [
+                            {
+                              "endDate": null,
+                              "eventId": 5,
+                              "id": 5,
+                              "location": "Antalya, Lithuania",
+                              "raceType": {
+                                "description": "Road Race Type",
+                                "id": 1,
+                                "name": "Road"
+                              },
+                              "raceTypeId": 1,
+                              "startDate": "2021-06-27"
+                            }
+                          ],
+                          "id": 5,
+                          "name": "Dao Timmi Shahdol"
+                        },
+                        "eventId": 5,
+                        "id": 176,
+                        "lap": null,
+                        "noPlaceCodeType": {
+                          "description": "Participant Placed",
+                          "id": 1,
+                          "name": "NA"
+                        },
+                        "noPlaceCodeTypeId": 1,
+                        "place": 5,
+                        "points": 55,
+                        "resultType": {
+                          "description": "Default Result Type",
+                          "id": 1,
+                          "name": "default"
+                        },
+                        "resultTypeId": 1,
+                        "rider": {
+                          "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                          "country": "Greece",
+                          "dob": "Sun Jan 14 2001",
+                          "firstName": "Cyclistopher",
+                          "hometown": "Mildura",
+                          "id": 44,
+                          "insta": "hxutcmnydtyyiih",
+                          "lastName": "Velocepede",
+                          "photo": "https://www.procyclingstats.com/images/riders/bp/eb/jens-keukeleire-2023.jpeg",
+                          "strava": "9209250"
+                        },
+                        "riderId": 44,
+                        "time": ""
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -259,7 +6196,775 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "a list of recent Results",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:24:19 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/races/results/recent?limit=2&resultlimit=3"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "raceId": {
+                        "type": "number",
+                        "example": 150
+                      },
+                      "results": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "event": {
+                              "type": "object",
+                              "properties": {
+                                "Race": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "endDate": {
+                                        "nullable": true,
+                                        "example": null
+                                      },
+                                      "eventId": {
+                                        "type": "number",
+                                        "example": 150
+                                      },
+                                      "id": {
+                                        "type": "number",
+                                        "example": 150
+                                      },
+                                      "location": {
+                                        "type": "string",
+                                        "example": "Akola, Ukraine"
+                                      },
+                                      "raceType": {
+                                        "type": "object",
+                                        "properties": {
+                                          "description": {
+                                            "type": "string",
+                                            "example": "Road Race Type"
+                                          },
+                                          "id": {
+                                            "type": "number",
+                                            "example": 1
+                                          },
+                                          "name": {
+                                            "type": "string",
+                                            "example": "Road"
+                                          }
+                                        }
+                                      },
+                                      "raceTypeId": {
+                                        "type": "number",
+                                        "example": 1
+                                      },
+                                      "startDate": {
+                                        "type": "string",
+                                        "example": "2024-11-06"
+                                      }
+                                    }
+                                  },
+                                  "example": [
+                                    {
+                                      "endDate": null,
+                                      "eventId": 150,
+                                      "id": 150,
+                                      "location": "Akola, Ukraine",
+                                      "raceType": {
+                                        "description": "Road Race Type",
+                                        "id": 1,
+                                        "name": "Road"
+                                      },
+                                      "raceTypeId": 1,
+                                      "startDate": "2024-11-06"
+                                    }
+                                  ]
+                                },
+                                "id": {
+                                  "type": "number",
+                                  "example": 150
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "Djado Plateau a Al Malaqi"
+                                }
+                              }
+                            },
+                            "eventId": {
+                              "type": "number",
+                              "example": 150
+                            },
+                            "id": {
+                              "type": "number",
+                              "example": 5222
+                            },
+                            "lap": {
+                              "nullable": true,
+                              "example": null
+                            },
+                            "noPlaceCodeType": {
+                              "type": "object",
+                              "properties": {
+                                "description": {
+                                  "type": "string",
+                                  "example": "Participant Placed"
+                                },
+                                "id": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "NA"
+                                }
+                              }
+                            },
+                            "noPlaceCodeTypeId": {
+                              "type": "number",
+                              "example": 1
+                            },
+                            "place": {
+                              "type": "number",
+                              "example": 1
+                            },
+                            "points": {
+                              "type": "number",
+                              "example": 114
+                            },
+                            "resultType": {
+                              "type": "object",
+                              "properties": {
+                                "description": {
+                                  "type": "string",
+                                  "example": "Default Result Type"
+                                },
+                                "id": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "default"
+                                }
+                              }
+                            },
+                            "resultTypeId": {
+                              "type": "number",
+                              "example": 1
+                            },
+                            "rider": {
+                              "type": "object",
+                              "properties": {
+                                "about": {
+                                  "type": "string",
+                                  "example": "They think I'm just some dumb hick. They said that to me, at a dinner!"
+                                },
+                                "country": {
+                                  "type": "string",
+                                  "example": "Greece"
+                                },
+                                "dob": {
+                                  "type": "string",
+                                  "example": "Mon Jun 10 1985"
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "example": "Laurens"
+                                },
+                                "hometown": {
+                                  "type": "string",
+                                  "example": "Modena"
+                                },
+                                "id": {
+                                  "type": "number",
+                                  "example": 48
+                                },
+                                "insta": {
+                                  "type": "string",
+                                  "example": "groxqsfmpy"
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "example": "Grimay"
+                                },
+                                "photo": {
+                                  "type": "string",
+                                  "example": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg"
+                                },
+                                "strava": {
+                                  "type": "string",
+                                  "example": "3734063"
+                                }
+                              }
+                            },
+                            "riderId": {
+                              "type": "number",
+                              "example": 48
+                            },
+                            "time": {
+                              "type": "string",
+                              "example": ""
+                            }
+                          }
+                        },
+                        "example": [
+                          {
+                            "event": {
+                              "Race": [
+                                {
+                                  "endDate": null,
+                                  "eventId": 150,
+                                  "id": 150,
+                                  "location": "Akola, Ukraine",
+                                  "raceType": {
+                                    "description": "Road Race Type",
+                                    "id": 1,
+                                    "name": "Road"
+                                  },
+                                  "raceTypeId": 1,
+                                  "startDate": "2024-11-06"
+                                }
+                              ],
+                              "id": 150,
+                              "name": "Djado Plateau a Al Malaqi"
+                            },
+                            "eventId": 150,
+                            "id": 5222,
+                            "lap": null,
+                            "noPlaceCodeType": {
+                              "description": "Participant Placed",
+                              "id": 1,
+                              "name": "NA"
+                            },
+                            "noPlaceCodeTypeId": 1,
+                            "place": 1,
+                            "points": 114,
+                            "resultType": {
+                              "description": "Default Result Type",
+                              "id": 1,
+                              "name": "default"
+                            },
+                            "resultTypeId": 1,
+                            "rider": {
+                              "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                              "country": "Greece",
+                              "dob": "Mon Jun 10 1985",
+                              "firstName": "Laurens",
+                              "hometown": "Modena",
+                              "id": 48,
+                              "insta": "groxqsfmpy",
+                              "lastName": "Grimay",
+                              "photo": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg",
+                              "strava": "3734063"
+                            },
+                            "riderId": 48,
+                            "time": ""
+                          },
+                          {
+                            "event": {
+                              "Race": [
+                                {
+                                  "endDate": null,
+                                  "eventId": 150,
+                                  "id": 150,
+                                  "location": "Akola, Ukraine",
+                                  "raceType": {
+                                    "description": "Road Race Type",
+                                    "id": 1,
+                                    "name": "Road"
+                                  },
+                                  "raceTypeId": 1,
+                                  "startDate": "2024-11-06"
+                                }
+                              ],
+                              "id": 150,
+                              "name": "Djado Plateau a Al Malaqi"
+                            },
+                            "eventId": 150,
+                            "id": 5206,
+                            "lap": null,
+                            "noPlaceCodeType": {
+                              "description": "Participant Placed",
+                              "id": 1,
+                              "name": "NA"
+                            },
+                            "noPlaceCodeTypeId": 1,
+                            "place": 2,
+                            "points": 99,
+                            "resultType": {
+                              "description": "Default Result Type",
+                              "id": 1,
+                              "name": "default"
+                            },
+                            "resultTypeId": 1,
+                            "rider": {
+                              "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                              "country": "Sweden",
+                              "dob": "Sat Jun 05 2004",
+                              "firstName": "Harold",
+                              "hometown": "Seoni",
+                              "id": 35,
+                              "insta": "efatihvkf",
+                              "lastName": "Koolkoolkool",
+                              "photo": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg",
+                              "strava": "4893701"
+                            },
+                            "riderId": 35,
+                            "time": ""
+                          },
+                          {
+                            "event": {
+                              "Race": [
+                                {
+                                  "endDate": null,
+                                  "eventId": 150,
+                                  "id": 150,
+                                  "location": "Akola, Ukraine",
+                                  "raceType": {
+                                    "description": "Road Race Type",
+                                    "id": 1,
+                                    "name": "Road"
+                                  },
+                                  "raceTypeId": 1,
+                                  "startDate": "2024-11-06"
+                                }
+                              ],
+                              "id": 150,
+                              "name": "Djado Plateau a Al Malaqi"
+                            },
+                            "eventId": 150,
+                            "id": 5225,
+                            "lap": null,
+                            "noPlaceCodeType": {
+                              "description": "Participant Placed",
+                              "id": 1,
+                              "name": "NA"
+                            },
+                            "noPlaceCodeTypeId": 1,
+                            "place": 3,
+                            "points": 84,
+                            "resultType": {
+                              "description": "Default Result Type",
+                              "id": 1,
+                              "name": "default"
+                            },
+                            "resultTypeId": 1,
+                            "rider": {
+                              "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                              "country": "Guatemala",
+                              "dob": "Thu Apr 26 2001",
+                              "firstName": "Cecilie",
+                              "hometown": "Broken Hill",
+                              "id": 49,
+                              "insta": "g",
+                              "lastName": "Markrus",
+                              "photo": "https://www.procyclingstats.com/images/riders/bp/aa/richard-carapaz-2024.jpeg",
+                              "strava": "1599291"
+                            },
+                            "riderId": 49,
+                            "time": ""
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "raceId": 150,
+                      "results": [
+                        {
+                          "event": {
+                            "Race": [
+                              {
+                                "endDate": null,
+                                "eventId": 150,
+                                "id": 150,
+                                "location": "Akola, Ukraine",
+                                "raceType": {
+                                  "description": "Road Race Type",
+                                  "id": 1,
+                                  "name": "Road"
+                                },
+                                "raceTypeId": 1,
+                                "startDate": "2024-11-06"
+                              }
+                            ],
+                            "id": 150,
+                            "name": "Djado Plateau a Al Malaqi"
+                          },
+                          "eventId": 150,
+                          "id": 5222,
+                          "lap": null,
+                          "noPlaceCodeType": {
+                            "description": "Participant Placed",
+                            "id": 1,
+                            "name": "NA"
+                          },
+                          "noPlaceCodeTypeId": 1,
+                          "place": 1,
+                          "points": 114,
+                          "resultType": {
+                            "description": "Default Result Type",
+                            "id": 1,
+                            "name": "default"
+                          },
+                          "resultTypeId": 1,
+                          "rider": {
+                            "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                            "country": "Greece",
+                            "dob": "Mon Jun 10 1985",
+                            "firstName": "Laurens",
+                            "hometown": "Modena",
+                            "id": 48,
+                            "insta": "groxqsfmpy",
+                            "lastName": "Grimay",
+                            "photo": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg",
+                            "strava": "3734063"
+                          },
+                          "riderId": 48,
+                          "time": ""
+                        },
+                        {
+                          "event": {
+                            "Race": [
+                              {
+                                "endDate": null,
+                                "eventId": 150,
+                                "id": 150,
+                                "location": "Akola, Ukraine",
+                                "raceType": {
+                                  "description": "Road Race Type",
+                                  "id": 1,
+                                  "name": "Road"
+                                },
+                                "raceTypeId": 1,
+                                "startDate": "2024-11-06"
+                              }
+                            ],
+                            "id": 150,
+                            "name": "Djado Plateau a Al Malaqi"
+                          },
+                          "eventId": 150,
+                          "id": 5206,
+                          "lap": null,
+                          "noPlaceCodeType": {
+                            "description": "Participant Placed",
+                            "id": 1,
+                            "name": "NA"
+                          },
+                          "noPlaceCodeTypeId": 1,
+                          "place": 2,
+                          "points": 99,
+                          "resultType": {
+                            "description": "Default Result Type",
+                            "id": 1,
+                            "name": "default"
+                          },
+                          "resultTypeId": 1,
+                          "rider": {
+                            "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                            "country": "Sweden",
+                            "dob": "Sat Jun 05 2004",
+                            "firstName": "Harold",
+                            "hometown": "Seoni",
+                            "id": 35,
+                            "insta": "efatihvkf",
+                            "lastName": "Koolkoolkool",
+                            "photo": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg",
+                            "strava": "4893701"
+                          },
+                          "riderId": 35,
+                          "time": ""
+                        },
+                        {
+                          "event": {
+                            "Race": [
+                              {
+                                "endDate": null,
+                                "eventId": 150,
+                                "id": 150,
+                                "location": "Akola, Ukraine",
+                                "raceType": {
+                                  "description": "Road Race Type",
+                                  "id": 1,
+                                  "name": "Road"
+                                },
+                                "raceTypeId": 1,
+                                "startDate": "2024-11-06"
+                              }
+                            ],
+                            "id": 150,
+                            "name": "Djado Plateau a Al Malaqi"
+                          },
+                          "eventId": 150,
+                          "id": 5225,
+                          "lap": null,
+                          "noPlaceCodeType": {
+                            "description": "Participant Placed",
+                            "id": 1,
+                            "name": "NA"
+                          },
+                          "noPlaceCodeTypeId": 1,
+                          "place": 3,
+                          "points": 84,
+                          "resultType": {
+                            "description": "Default Result Type",
+                            "id": 1,
+                            "name": "default"
+                          },
+                          "resultTypeId": 1,
+                          "rider": {
+                            "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                            "country": "Guatemala",
+                            "dob": "Thu Apr 26 2001",
+                            "firstName": "Cecilie",
+                            "hometown": "Broken Hill",
+                            "id": 49,
+                            "insta": "g",
+                            "lastName": "Markrus",
+                            "photo": "https://www.procyclingstats.com/images/riders/bp/aa/richard-carapaz-2024.jpeg",
+                            "strava": "1599291"
+                          },
+                          "riderId": 49,
+                          "time": ""
+                        }
+                      ]
+                    },
+                    {
+                      "raceId": 490,
+                      "results": []
+                    }
+                  ]
+                },
+                "examples": {
+                  "a list of recent Results": {
+                    "value": [
+                      {
+                        "raceId": 150,
+                        "results": [
+                          {
+                            "event": {
+                              "Race": [
+                                {
+                                  "endDate": null,
+                                  "eventId": 150,
+                                  "id": 150,
+                                  "location": "Akola, Ukraine",
+                                  "raceType": {
+                                    "description": "Road Race Type",
+                                    "id": 1,
+                                    "name": "Road"
+                                  },
+                                  "raceTypeId": 1,
+                                  "startDate": "2024-11-06"
+                                }
+                              ],
+                              "id": 150,
+                              "name": "Djado Plateau a Al Malaqi"
+                            },
+                            "eventId": 150,
+                            "id": 5222,
+                            "lap": null,
+                            "noPlaceCodeType": {
+                              "description": "Participant Placed",
+                              "id": 1,
+                              "name": "NA"
+                            },
+                            "noPlaceCodeTypeId": 1,
+                            "place": 1,
+                            "points": 114,
+                            "resultType": {
+                              "description": "Default Result Type",
+                              "id": 1,
+                              "name": "default"
+                            },
+                            "resultTypeId": 1,
+                            "rider": {
+                              "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                              "country": "Greece",
+                              "dob": "Mon Jun 10 1985",
+                              "firstName": "Laurens",
+                              "hometown": "Modena",
+                              "id": 48,
+                              "insta": "groxqsfmpy",
+                              "lastName": "Grimay",
+                              "photo": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg",
+                              "strava": "3734063"
+                            },
+                            "riderId": 48,
+                            "time": ""
+                          },
+                          {
+                            "event": {
+                              "Race": [
+                                {
+                                  "endDate": null,
+                                  "eventId": 150,
+                                  "id": 150,
+                                  "location": "Akola, Ukraine",
+                                  "raceType": {
+                                    "description": "Road Race Type",
+                                    "id": 1,
+                                    "name": "Road"
+                                  },
+                                  "raceTypeId": 1,
+                                  "startDate": "2024-11-06"
+                                }
+                              ],
+                              "id": 150,
+                              "name": "Djado Plateau a Al Malaqi"
+                            },
+                            "eventId": 150,
+                            "id": 5206,
+                            "lap": null,
+                            "noPlaceCodeType": {
+                              "description": "Participant Placed",
+                              "id": 1,
+                              "name": "NA"
+                            },
+                            "noPlaceCodeTypeId": 1,
+                            "place": 2,
+                            "points": 99,
+                            "resultType": {
+                              "description": "Default Result Type",
+                              "id": 1,
+                              "name": "default"
+                            },
+                            "resultTypeId": 1,
+                            "rider": {
+                              "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                              "country": "Sweden",
+                              "dob": "Sat Jun 05 2004",
+                              "firstName": "Harold",
+                              "hometown": "Seoni",
+                              "id": 35,
+                              "insta": "efatihvkf",
+                              "lastName": "Koolkoolkool",
+                              "photo": "https://www.procyclingstats.com/images/riders/bp/ee/neilson-powless-2024.jpeg",
+                              "strava": "4893701"
+                            },
+                            "riderId": 35,
+                            "time": ""
+                          },
+                          {
+                            "event": {
+                              "Race": [
+                                {
+                                  "endDate": null,
+                                  "eventId": 150,
+                                  "id": 150,
+                                  "location": "Akola, Ukraine",
+                                  "raceType": {
+                                    "description": "Road Race Type",
+                                    "id": 1,
+                                    "name": "Road"
+                                  },
+                                  "raceTypeId": 1,
+                                  "startDate": "2024-11-06"
+                                }
+                              ],
+                              "id": 150,
+                              "name": "Djado Plateau a Al Malaqi"
+                            },
+                            "eventId": 150,
+                            "id": 5225,
+                            "lap": null,
+                            "noPlaceCodeType": {
+                              "description": "Participant Placed",
+                              "id": 1,
+                              "name": "NA"
+                            },
+                            "noPlaceCodeTypeId": 1,
+                            "place": 3,
+                            "points": 84,
+                            "resultType": {
+                              "description": "Default Result Type",
+                              "id": 1,
+                              "name": "default"
+                            },
+                            "resultTypeId": 1,
+                            "rider": {
+                              "about": "They think I'm just some dumb hick. They said that to me, at a dinner!",
+                              "country": "Guatemala",
+                              "dob": "Thu Apr 26 2001",
+                              "firstName": "Cecilie",
+                              "hometown": "Broken Hill",
+                              "id": 49,
+                              "insta": "g",
+                              "lastName": "Markrus",
+                              "photo": "https://www.procyclingstats.com/images/riders/bp/aa/richard-carapaz-2024.jpeg",
+                              "strava": "1599291"
+                            },
+                            "riderId": 49,
+                            "time": ""
+                          }
+                        ]
+                      },
+                      {
+                        "raceId": 490,
+                        "results": []
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -285,7 +6990,230 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "a list of Results for a single Rider",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:25:40 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/results?riderId=52"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "races": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "category": {
+                                  "type": "string",
+                                  "example": "1"
+                                },
+                                "endDate": {
+                                  "nullable": true,
+                                  "example": null
+                                },
+                                "eventId": {
+                                  "type": "number",
+                                  "example": 505
+                                },
+                                "id": {
+                                  "type": "number",
+                                  "example": 504
+                                },
+                                "lap": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "location": {
+                                  "type": "string",
+                                  "example": "sumwhere, europe"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "myracev2"
+                                },
+                                "noPlaceCode": {
+                                  "type": "string",
+                                  "example": "NA"
+                                },
+                                "place": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "points": {
+                                  "type": "number",
+                                  "example": 99
+                                },
+                                "racers": {
+                                  "type": "number",
+                                  "example": 20
+                                },
+                                "resultType": {
+                                  "type": "string",
+                                  "example": "default"
+                                },
+                                "startDate": {
+                                  "type": "string",
+                                  "example": "2024-10-03"
+                                },
+                                "time": {
+                                  "type": "string",
+                                  "example": "23:40.93"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "example": "Road"
+                                }
+                              }
+                            },
+                            "example": [
+                              {
+                                "category": "1",
+                                "endDate": null,
+                                "eventId": 505,
+                                "id": 504,
+                                "lap": 1,
+                                "location": "sumwhere, europe",
+                                "name": "myracev2",
+                                "noPlaceCode": "NA",
+                                "place": 1,
+                                "points": 99,
+                                "racers": 20,
+                                "resultType": "default",
+                                "startDate": "2024-10-03",
+                                "time": "23:40.93",
+                                "type": "Road"
+                              }
+                            ]
+                          },
+                          "year": {
+                            "type": "number",
+                            "example": 2024
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "races": [
+                            {
+                              "category": "1",
+                              "endDate": null,
+                              "eventId": 505,
+                              "id": 504,
+                              "lap": 1,
+                              "location": "sumwhere, europe",
+                              "name": "myracev2",
+                              "noPlaceCode": "NA",
+                              "place": 1,
+                              "points": 99,
+                              "racers": 20,
+                              "resultType": "default",
+                              "startDate": "2024-10-03",
+                              "time": "23:40.93",
+                              "type": "Road"
+                            }
+                          ],
+                          "year": 2024
+                        }
+                      ]
+                    },
+                    "riderId": {
+                      "type": "number",
+                      "example": 52
+                    }
+                  }
+                },
+                "examples": {
+                  "a list of Results for a single Rider": {
+                    "value": {
+                      "results": [
+                        {
+                          "races": [
+                            {
+                              "category": "1",
+                              "endDate": null,
+                              "eventId": 505,
+                              "id": 504,
+                              "lap": 1,
+                              "location": "sumwhere, europe",
+                              "name": "myracev2",
+                              "noPlaceCode": "NA",
+                              "place": 1,
+                              "points": 99,
+                              "racers": 20,
+                              "resultType": "default",
+                              "startDate": "2024-10-03",
+                              "time": "23:40.93",
+                              "type": "Road"
+                            }
+                          ],
+                          "year": 2024
+                        }
+                      ],
+                      "riderId": 52
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -355,7 +7283,123 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "a new Result",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:24:32 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/results"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "eventId": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "id": {
+                      "type": "number",
+                      "example": 17190
+                    },
+                    "lap": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "noPlaceCodeTypeId": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "place": {
+                      "type": "number",
+                      "example": 4
+                    },
+                    "points": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "resultTypeId": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "riderId": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "time": {
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                },
+                "examples": {
+                  "a new Result": {
+                    "value": {
+                      "eventId": 1,
+                      "id": 17190,
+                      "lap": 1,
+                      "noPlaceCodeTypeId": 1,
+                      "place": 4,
+                      "points": 1,
+                      "resultTypeId": 1,
+                      "riderId": 1,
+                      "time": null
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -432,7 +7476,128 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "a new Rider",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:25:55 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/riders"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "about": {
+                      "type": "string",
+                      "example": "It reaaaallly bothered me."
+                    },
+                    "country": {
+                      "type": "string",
+                      "example": "USA"
+                    },
+                    "dob": {
+                      "type": "string",
+                      "example": "1990-01-01"
+                    },
+                    "firstName": {
+                      "type": "string",
+                      "example": "Mipper"
+                    },
+                    "hometown": {
+                      "type": "string",
+                      "example": "New York, NY"
+                    },
+                    "id": {
+                      "type": "number",
+                      "example": 74
+                    },
+                    "insta": {
+                      "type": "string",
+                      "example": "portamip"
+                    },
+                    "lastName": {
+                      "type": "string",
+                      "example": "Mopperson"
+                    },
+                    "photo": {
+                      "type": "string",
+                      "example": "https://www.procyclingstats.com/images/riders/bp/bf/julian-alaphilippe-2024.jpeg"
+                    },
+                    "strava": {
+                      "type": "string",
+                      "example": "87935790234"
+                    }
+                  }
+                },
+                "examples": {
+                  "a new Rider": {
+                    "value": {
+                      "about": "It reaaaallly bothered me.",
+                      "country": "USA",
+                      "dob": "1990-01-01",
+                      "firstName": "Mipper",
+                      "hometown": "New York, NY",
+                      "id": 74,
+                      "insta": "portamip",
+                      "lastName": "Mopperson",
+                      "photo": "https://www.procyclingstats.com/images/riders/bp/bf/julian-alaphilippe-2024.jpeg",
+                      "strava": "87935790234"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -447,7 +7612,228 @@
         "operationId": "aSingleRider",
         "responses": {
           "200": {
-            "description": ""
+            "description": "a single Rider",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:26:26 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/riders/4"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "categories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "category": {
+                            "type": "number",
+                            "example": 1
+                          },
+                          "disicpline": {
+                            "type": "string",
+                            "example": "road"
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "category": 1,
+                          "disicpline": "road"
+                        }
+                      ]
+                    },
+                    "currentTeam": {
+                      "type": "string",
+                      "example": "TJ Maxx Equipo"
+                    },
+                    "dob": {
+                      "type": "string",
+                      "example": "Sat Jun 27 1998"
+                    },
+                    "hometown": {
+                      "type": "object",
+                      "properties": {
+                        "city": {
+                          "type": "string",
+                          "example": "Copenhagen"
+                        },
+                        "country": {
+                          "type": "string",
+                          "example": "Syria"
+                        }
+                      }
+                    },
+                    "id": {
+                      "type": "number",
+                      "example": 4
+                    },
+                    "name": {
+                      "type": "object",
+                      "properties": {
+                        "first": {
+                          "type": "string",
+                          "example": "Geraint"
+                        },
+                        "last": {
+                          "type": "string",
+                          "example": "Kamna"
+                        }
+                      }
+                    },
+                    "photo": {
+                      "type": "string",
+                      "example": "https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg"
+                    },
+                    "socials": {
+                      "type": "object",
+                      "properties": {
+                        "insta": {
+                          "type": "string",
+                          "example": "j"
+                        },
+                        "strava": {
+                          "type": "string",
+                          "example": "715907"
+                        }
+                      }
+                    },
+                    "teams": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "description": {
+                            "type": "string",
+                            "example": "TJ Maxx Equipo is a racing community. We help each other keep things dialed on and off the bike to realize one another's  athletic goals."
+                          },
+                          "id": {
+                            "type": "number",
+                            "example": 3
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "TJ Maxx Equipo"
+                          },
+                          "url": {
+                            "type": "string",
+                            "example": ""
+                          },
+                          "year": {
+                            "type": "number",
+                            "example": 2024
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "description": "TJ Maxx Equipo is a racing community. We help each other keep things dialed on and off the bike to realize one another's  athletic goals.",
+                          "id": 3,
+                          "name": "TJ Maxx Equipo",
+                          "url": "",
+                          "year": 2024
+                        }
+                      ]
+                    },
+                    "wins": {
+                      "type": "number",
+                      "example": 43
+                    }
+                  }
+                },
+                "examples": {
+                  "a single Rider": {
+                    "value": {
+                      "categories": [
+                        {
+                          "category": 1,
+                          "disicpline": "road"
+                        }
+                      ],
+                      "currentTeam": "TJ Maxx Equipo",
+                      "dob": "Sat Jun 27 1998",
+                      "hometown": {
+                        "city": "Copenhagen",
+                        "country": "Syria"
+                      },
+                      "id": 4,
+                      "name": {
+                        "first": "Geraint",
+                        "last": "Kamna"
+                      },
+                      "photo": "https://www.procyclingstats.com/images/riders/bp/ca/egan-bernal-2024.jpg",
+                      "socials": {
+                        "insta": "j",
+                        "strava": "715907"
+                      },
+                      "teams": [
+                        {
+                          "description": "TJ Maxx Equipo is a racing community. We help each other keep things dialed on and off the bike to realize one another's  athletic goals.",
+                          "id": 3,
+                          "name": "TJ Maxx Equipo",
+                          "url": "",
+                          "year": 2024
+                        }
+                      ],
+                      "wins": 43
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -484,7 +7870,93 @@
         },
         "responses": {
           "200": {
-            "description": ""
+            "description": "http://localhost:8080/api/latest/riders/1/teams",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:27:11 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/riders/4/teams"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number",
+                      "example": 56
+                    },
+                    "riderId": {
+                      "type": "number",
+                      "example": 4
+                    },
+                    "teamId": {
+                      "type": "number",
+                      "example": 2
+                    }
+                  }
+                },
+                "examples": {
+                  "http://localhost:8080/api/latest/riders/1/teams": {
+                    "value": {
+                      "id": 56,
+                      "riderId": 4,
+                      "teamId": 2
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -519,7 +7991,187 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "a list of Riders by Rank",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:27:31 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/riders/rankings?limit=5&year=2024"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "country": {
+                        "type": "string",
+                        "example": "Chile"
+                      },
+                      "firstName": {
+                        "type": "string",
+                        "example": "Demi"
+                      },
+                      "hometown": {
+                        "type": "string",
+                        "example": "Prague"
+                      },
+                      "lastName": {
+                        "type": "string",
+                        "example": "Squiban"
+                      },
+                      "riderId": {
+                        "type": "number",
+                        "example": 25
+                      },
+                      "totalPoints": {
+                        "type": "number",
+                        "example": 1373
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "country": "Chile",
+                      "firstName": "Demi",
+                      "hometown": "Prague",
+                      "lastName": "Squiban",
+                      "riderId": 25,
+                      "totalPoints": 1373
+                    },
+                    {
+                      "country": "Greece",
+                      "firstName": "Xandro",
+                      "hometown": "Reykjavik",
+                      "lastName": "Sormano",
+                      "riderId": 34,
+                      "totalPoints": 1227
+                    },
+                    {
+                      "country": "Germany",
+                      "firstName": "Katarzyna",
+                      "hometown": "Brussels",
+                      "lastName": "Kamna",
+                      "riderId": 18,
+                      "totalPoints": 1181
+                    },
+                    {
+                      "country": "Norway",
+                      "firstName": "Dynamo",
+                      "hometown": "Rijeka",
+                      "lastName": "Torqueheed",
+                      "riderId": 31,
+                      "totalPoints": 1153
+                    },
+                    {
+                      "country": "Ukraine",
+                      "firstName": "Spedvagon",
+                      "hometown": "Chiang Mai",
+                      "lastName": "De Minus",
+                      "riderId": 19,
+                      "totalPoints": 1128
+                    }
+                  ]
+                },
+                "examples": {
+                  "a list of Riders by Rank": {
+                    "value": [
+                      {
+                        "country": "Chile",
+                        "firstName": "Demi",
+                        "hometown": "Prague",
+                        "lastName": "Squiban",
+                        "riderId": 25,
+                        "totalPoints": 1373
+                      },
+                      {
+                        "country": "Greece",
+                        "firstName": "Xandro",
+                        "hometown": "Reykjavik",
+                        "lastName": "Sormano",
+                        "riderId": 34,
+                        "totalPoints": 1227
+                      },
+                      {
+                        "country": "Germany",
+                        "firstName": "Katarzyna",
+                        "hometown": "Brussels",
+                        "lastName": "Kamna",
+                        "riderId": 18,
+                        "totalPoints": 1181
+                      },
+                      {
+                        "country": "Norway",
+                        "firstName": "Dynamo",
+                        "hometown": "Rijeka",
+                        "lastName": "Torqueheed",
+                        "riderId": 31,
+                        "totalPoints": 1153
+                      },
+                      {
+                        "country": "Ukraine",
+                        "firstName": "Spedvagon",
+                        "hometown": "Chiang Mai",
+                        "lastName": "De Minus",
+                        "riderId": 19,
+                        "totalPoints": 1128
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -8175,6 +8175,244 @@
           }
         }
       }
+    },
+    "/api/v1/riders/52/results": {
+      "get": {
+        "tags": [
+          "Riders"
+        ],
+        "summary": "a list of Results for a single RIder",
+        "description": "a list of Results for a single RIder",
+        "operationId": "aListOfResultsForASingleRider1",
+        "responses": {
+          "200": {
+            "description": "a list of Results for a single RIder",
+            "headers": {
+              "Connection": {
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
+              },
+              "Date": {
+                "schema": {
+                  "type": "string",
+                  "example": "Mon, 18 Nov 2024 01:48:27 GMT"
+                }
+              },
+              "Keep-Alive": {
+                "schema": {
+                  "type": "string",
+                  "example": "timeout=5"
+                }
+              },
+              "Transfer-Encoding": {
+                "schema": {
+                  "type": "string",
+                  "example": "chunked"
+                }
+              },
+              "access-control-allow-headers": {
+                "schema": {
+                  "type": "string",
+                  "example": "Content-Type"
+                }
+              },
+              "access-control-allow-methods": {
+                "schema": {
+                  "type": "string",
+                  "example": "GET, POST, OPTIONS"
+                }
+              },
+              "access-control-allow-origin": {
+                "schema": {
+                  "type": "string",
+                  "example": "*"
+                }
+              },
+              "vary": {
+                "schema": {
+                  "type": "string",
+                  "example": "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch"
+                }
+              },
+              "x-middleware-rewrite": {
+                "schema": {
+                  "type": "string",
+                  "example": "/api/v1/riders/52/results"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "races": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "category": {
+                                  "type": "string",
+                                  "example": "1"
+                                },
+                                "endDate": {
+                                  "nullable": true,
+                                  "example": null
+                                },
+                                "eventId": {
+                                  "type": "number",
+                                  "example": 505
+                                },
+                                "id": {
+                                  "type": "number",
+                                  "example": 504
+                                },
+                                "lap": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "location": {
+                                  "type": "string",
+                                  "example": "sumwhere, europe"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "myracev2"
+                                },
+                                "noPlaceCode": {
+                                  "type": "string",
+                                  "example": "NA"
+                                },
+                                "place": {
+                                  "type": "number",
+                                  "example": 1
+                                },
+                                "points": {
+                                  "type": "number",
+                                  "example": 99
+                                },
+                                "racers": {
+                                  "type": "number",
+                                  "example": 20
+                                },
+                                "resultType": {
+                                  "type": "string",
+                                  "example": "default"
+                                },
+                                "startDate": {
+                                  "type": "string",
+                                  "example": "2024-10-03"
+                                },
+                                "time": {
+                                  "type": "string",
+                                  "example": "23:40.93"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "example": "Road"
+                                }
+                              }
+                            },
+                            "example": [
+                              {
+                                "category": "1",
+                                "endDate": null,
+                                "eventId": 505,
+                                "id": 504,
+                                "lap": 1,
+                                "location": "sumwhere, europe",
+                                "name": "myracev2",
+                                "noPlaceCode": "NA",
+                                "place": 1,
+                                "points": 99,
+                                "racers": 20,
+                                "resultType": "default",
+                                "startDate": "2024-10-03",
+                                "time": "23:40.93",
+                                "type": "Road"
+                              }
+                            ]
+                          },
+                          "year": {
+                            "type": "number",
+                            "example": 2024
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "races": [
+                            {
+                              "category": "1",
+                              "endDate": null,
+                              "eventId": 505,
+                              "id": 504,
+                              "lap": 1,
+                              "location": "sumwhere, europe",
+                              "name": "myracev2",
+                              "noPlaceCode": "NA",
+                              "place": 1,
+                              "points": 99,
+                              "racers": 20,
+                              "resultType": "default",
+                              "startDate": "2024-10-03",
+                              "time": "23:40.93",
+                              "type": "Road"
+                            }
+                          ],
+                          "year": 2024
+                        }
+                      ]
+                    },
+                    "riderId": {
+                      "type": "number",
+                      "example": 52
+                    }
+                  }
+                },
+                "examples": {
+                  "a list of Results for a single RIder": {
+                    "value": {
+                      "results": [
+                        {
+                          "races": [
+                            {
+                              "category": "1",
+                              "endDate": null,
+                              "eventId": 505,
+                              "id": 504,
+                              "lap": 1,
+                              "location": "sumwhere, europe",
+                              "name": "myracev2",
+                              "noPlaceCode": "NA",
+                              "place": 1,
+                              "points": 99,
+                              "racers": 20,
+                              "resultType": "default",
+                              "startDate": "2024-10-03",
+                              "time": "23:40.93",
+                              "type": "Road"
+                            }
+                          ],
+                          "year": 2024
+                        }
+                      ],
+                      "riderId": 52
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "tags": [


### PR DESCRIPTION
Existing endpoint:

`GET /results?riderId=[id]`
- returns results for a single rider

New endpoint:
`GET /riders/[id]/results`
- returns results for a single rider

Old endpoint will be removed after the front end is updated

Also updated the documentation